### PR TITLE
fix: enable esm server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
+  "_comment": [
+    "Summary: Node package manifest for Tanks for Nothing, a minimal multiplayer tank demo.",
+    "Structure: defines npm scripts, module type, and runtime dependencies.",
+    "Usage: Run 'npm install' to install dependencies, then 'npm start' to launch the server."
+  ],
   "name": "tanksfornothing",
   "version": "1.0.0",
   "description": "Blocky multiplayer tank game",
-  "main": "index.js",
+  "main": "tanksfornothing-server.js",
   "scripts": {
     "test": "node -e \"console.log('no tests yet')\"",
     "start": "node tanksfornothing-server.js",
@@ -11,7 +16,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- switch project to ES modules by declaring `type: module`
- document package manifest with an inline `_comment`

## Testing
- `npm test`
- `PORT=4000 timeout 5 npm start`

------
https://chatgpt.com/codex/tasks/task_e_68ab6db3f6348328b93b1d185c73ec4b