### PR TITLE
Add client-side error handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,10 @@
   <nav id="navbar"><span>Tanks for Nothing</span></nav>
   <div id="instructions">WASD move | Mouse look | C freelook | V camera | Scroll zoom | 1-4 ammo</div>
   <script src="/socket.io/socket.io.js"></script>
-  <script type="module" src="tanksfornothing-client.js"></script>
+  <script
+    type="module"
+    src="tanksfornothing-client.js"
+    onerror="console.error('Failed to load client module');document.body.innerHTML='<div style=\'margin-top:2em;text-align:center;color:red\'>Failed to load game client.</div>'"
+  ></script>
 </body>
 </html>

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -24,6 +24,10 @@ function showError(message) {
 }
 
 window.addEventListener('error', (e) => showError(`Error: ${e.message}`));
+// Capture unhandled promise rejections to surface asynchronous errors.
+window.addEventListener('unhandledrejection', (e) => {
+  showError('Promise error: ' + e.reason);
+});
 
 // `io` is provided globally by the socket.io script tag in index.html. Create a
 // socket when available and surface connection issues to the player.


### PR DESCRIPTION
## Summary
- surface unhandled promise rejections in the game client
- show a helpful message if the client module fails to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8489087c8328ad863fcf80045500