### PR TITLE
Persist tank data and extend admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ A minimal browser-based multiplayer tank demo built with Node.js, Express, Socke
 - Node.js 18+ and npm
 
 ## Setup
+Run these commands from a terminal (PowerShell on Windows):
+
 ### Linux / macOS / Raspberry Pi
 ```bash
 cd tanksfornothing
 npm install
+npm run setup   # create data/tanks.json
 npm start
 ```
 
@@ -23,6 +26,7 @@ npm start
 ```powershell
 cd tanksfornothing
 npm install
+npm run setup   # create data/tanks.json
 npm start
 ```
 
@@ -30,13 +34,15 @@ The server listens on port **3000** by default. Use the `PORT` environment varia
 ```bash
 PORT=8080 npm start
 ```
+Set `NODE_ENV=production` when deploying to enable secure cookies.
 
 Set `ADMIN_PASSWORD` to change the admin login password (default `adminpass`).
 
 ## Usage
 - Open `http://localhost:3000` in a modern browser.
 - Click the screen to capture the mouse and drive the tank.
-- Visit `http://localhost:3000/admin/admin.html` for the admin panel.
+- Visit `http://localhost:3000/admin/admin.html` for the admin panel. The tank form now includes sliders for armor, caliber, crew,
+  engine power, incline and rotation speeds, ammo checkboxes, and a class dropdown. Tanks persist across restarts.
 
 ## Debugging
 The server logs player connections and updates to the console. Use `npm run dev` to auto-restart on changes.

--- a/admin/admin.html
+++ b/admin/admin.html
@@ -37,6 +37,42 @@
     <input id="tankName" placeholder="Name">
     <input id="tankNation" placeholder="Nation">
     <input id="tankBR" type="number" min="1" max="10" step="0.1" placeholder="BR">
+    <label>Armor (mm)
+      <input id="tankArmor" type="range" min="0" max="500" step="10" oninput="document.getElementById('armorVal').innerText=this.value">
+      <span id="armorVal"></span>
+    </label>
+    <label>Cannon Caliber (mm)
+      <input id="tankCaliber" type="range" min="20" max="200" step="5" oninput="document.getElementById('caliberVal').innerText=this.value">
+      <span id="caliberVal"></span>
+    </label>
+    <div id="tankAmmoOptions"></div>
+    <label>Crew Count
+      <input id="tankCrew" type="range" min="1" max="10" step="1" oninput="document.getElementById('crewVal').innerText=this.value">
+      <span id="crewVal"></span>
+    </label>
+    <label>Engine Horsepower
+      <input id="tankHP" type="range" min="50" max="2000" step="50" oninput="document.getElementById('hpVal').innerText=this.value">
+      <span id="hpVal"></span>
+    </label>
+    <label>Max Incline (°)
+      <input id="tankIncline" type="range" min="0" max="60" step="1" oninput="document.getElementById('inclineVal').innerText=this.value">
+      <span id="inclineVal"></span>
+    </label>
+    <label>Body Rotation Speed (°/s)
+      <input id="tankBodyRot" type="range" min="0" max="60" step="1" oninput="document.getElementById('bodyRotVal').innerText=this.value">
+      <span id="bodyRotVal"></span>
+    </label>
+    <label>Turret Rotation Speed (°/s)
+      <input id="tankTurretRot" type="range" min="0" max="60" step="1" oninput="document.getElementById('turretRotVal').innerText=this.value">
+      <span id="turretRotVal"></span>
+    </label>
+    <select id="tankClass">
+      <option value="Light">Light</option>
+      <option value="Medium">Medium</option>
+      <option value="Heavy">Heavy</option>
+      <option value="Tank Destroyer">Tank Destroyer</option>
+      <option value="SPAA">SPAA</option>
+    </select>
     <button onclick="addTank()">Add Tank</button>
 
     <h2>Ammo</h2>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -40,6 +40,8 @@ async function loadData() {
   document.getElementById('tankList').innerText = JSON.stringify(tanks);
   document.getElementById('ammoList').innerText = JSON.stringify(ammo);
   document.getElementById('terrainName').innerText = terrain.terrain;
+  const ammoDiv = document.getElementById('tankAmmoOptions');
+  ammoDiv.innerHTML = ammo.map(a => `<label><input type="checkbox" value="${a.name}">${a.name}</label>`).join('');
 }
 
 async function addTank() {
@@ -49,7 +51,16 @@ async function addTank() {
     body: JSON.stringify({
       name: document.getElementById('tankName').value,
       nation: document.getElementById('tankNation').value,
-      br: parseFloat(document.getElementById('tankBR').value)
+      br: parseFloat(document.getElementById('tankBR').value),
+      armor: parseInt(document.getElementById('tankArmor').value, 10),
+      cannonCaliber: parseInt(document.getElementById('tankCaliber').value, 10),
+      ammo: Array.from(document.querySelectorAll('#tankAmmoOptions input:checked')).map(cb => cb.value),
+      crew: parseInt(document.getElementById('tankCrew').value, 10),
+      engineHp: parseInt(document.getElementById('tankHP').value, 10),
+      incline: parseInt(document.getElementById('tankIncline').value, 10),
+      bodyRotation: parseInt(document.getElementById('tankBodyRot').value, 10),
+      turretRotation: parseInt(document.getElementById('tankTurretRot').value, 10),
+      class: document.getElementById('tankClass').value
     })
   });
   loadData();

--- a/data/tanks.json
+++ b/data/tanks.json
@@ -1,0 +1,8 @@
+{
+  "_comment": [
+    "Summary: Persisted tank definitions for Tanks for Nothing.",
+    "Structure: JSON object with _comment array and tanks list.",
+    "Usage: Managed automatically by server; do not edit manually."
+  ],
+  "tanks": []
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "node -e \"console.log('no tests yet')\"",
     "start": "node tanksfornothing-server.js",
-    "dev": "node --watch tanksfornothing-server.js"
+    "dev": "node --watch tanksfornothing-server.js",
+    "setup": "node scripts/init-data.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/init-data.js
+++ b/scripts/init-data.js
@@ -1,0 +1,30 @@
+// init-data.js
+// Summary: Ensures data directory and tanks.json exist for persistence.
+// Structure: create data folder -> write default tanks.json if missing.
+// Usage: Run with `node scripts/init-data.js` prior to starting server.
+// ---------------------------------------------------------------------------
+
+import { promises as fs } from 'fs';
+const dataDir = new URL('../data/', import.meta.url);
+const dataFile = new URL('tanks.json', dataDir);
+
+async function init() {
+  await fs.mkdir(dataDir, { recursive: true });
+  try {
+    await fs.access(dataFile);
+    console.log('tanks.json already exists');
+  } catch {
+    const data = {
+      _comment: [
+        'Summary: Persisted tank definitions for Tanks for Nothing.',
+        'Structure: JSON object with _comment array and tanks list.',
+        'Usage: Managed automatically by server; do not edit manually.'
+      ],
+      tanks: []
+    };
+    await fs.writeFile(dataFile, JSON.stringify(data, null, 2));
+    console.log('Created data/tanks.json');
+  }
+}
+
+init();

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -1,7 +1,7 @@
 // tanksfornothing-server.js
 // Summary: Entry point server for Tanks for Nothing, a minimal blocky multiplayer tank game.
-// This script sets up an Express web server with Socket.IO for real-time tank position updates.
-// Structure: configuration -> express setup -> socket handlers -> in-memory stores -> server start.
+// This script sets up an Express web server with Socket.IO for real-time tank position updates and persists admin-defined tanks to disk.
+// Structure: configuration -> express setup -> socket handlers -> in-memory stores -> persistence helpers -> server start.
 // Usage: Run with `node tanksfornothing-server.js` or `npm start`. Set PORT env to change port.
 // ---------------------------------------------------------------------------
 
@@ -9,6 +9,7 @@ import express from 'express';
 import http from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import cookieParser from 'cookie-parser';
+import { promises as fs } from 'fs';
 
 const app = express();
 const server = http.createServer(app);
@@ -18,12 +19,39 @@ const io = new SocketIOServer(server);
 const PORT = process.env.PORT || 3000;
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'adminpass';
 
-// In-memory stores
+// In-memory stores (tanks persisted to disk)
 const players = new Map(); // socket.id -> player state
-const tanks = []; // CRUD via admin
+let tanks = []; // CRUD via admin, loaded from JSON file
 const ammo = []; // CRUD via admin
 let terrain = 'flat';
 let baseBR = null; // Battle Rating of first player
+
+const DATA_FILE = new URL('./data/tanks.json', import.meta.url);
+
+async function loadTanks() {
+  try {
+    const text = await fs.readFile(DATA_FILE, 'utf8');
+    const json = JSON.parse(text);
+    if (Array.isArray(json.tanks)) tanks = json.tanks;
+  } catch {
+    console.warn('No existing tank data, starting with empty list');
+  }
+}
+
+async function saveTanks() {
+  await fs.mkdir(new URL('./data', import.meta.url), { recursive: true });
+  const data = {
+    _comment: [
+      'Summary: Persisted tank definitions for Tanks for Nothing.',
+      'Structure: JSON object with _comment array and tanks list.',
+      'Usage: Managed automatically by server; do not edit manually.'
+    ],
+    tanks
+  };
+  await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+await loadTanks();
 
 // Middleware
 app.use(express.static('public'));
@@ -70,8 +98,38 @@ app.get('/admin/status', (req, res) => {
 
 // Admin CRUD endpoints
 app.get('/api/tanks', (req, res) => res.json(tanks));
-app.post('/api/tanks', requireAdmin, (req, res) => {
-  tanks.push(req.body);
+app.post('/api/tanks', requireAdmin, async (req, res) => {
+  const t = req.body;
+  const classes = new Set(['Light', 'Medium', 'Heavy', 'Tank Destroyer', 'SPAA']);
+  if (typeof t.name !== 'string' || !t.name.trim()) return res.status(400).json({ error: 'name required' });
+  if (typeof t.nation !== 'string' || !t.nation.trim()) return res.status(400).json({ error: 'nation required' });
+  if (typeof t.br !== 'number' || t.br < 1 || t.br > 10) return res.status(400).json({ error: 'br out of range' });
+  if (typeof t.armor !== 'number' || t.armor < 0 || t.armor > 500) return res.status(400).json({ error: 'armor out of range' });
+  if (typeof t.cannonCaliber !== 'number' || t.cannonCaliber <= 0) return res.status(400).json({ error: 'invalid caliber' });
+  if (!Array.isArray(t.ammo) || !t.ammo.every(a => typeof a === 'string')) return res.status(400).json({ error: 'invalid ammo list' });
+  if (!Number.isInteger(t.crew) || t.crew <= 0) return res.status(400).json({ error: 'invalid crew count' });
+  if (typeof t.engineHp !== 'number' || t.engineHp <= 0) return res.status(400).json({ error: 'invalid engine hp' });
+  if (typeof t.incline !== 'number' || t.incline < 0 || t.incline > 60) return res.status(400).json({ error: 'incline out of range' });
+  if (typeof t.bodyRotation !== 'number' || t.bodyRotation < 0) return res.status(400).json({ error: 'invalid body rotation' });
+  if (typeof t.turretRotation !== 'number' || t.turretRotation < 0) return res.status(400).json({ error: 'invalid turret rotation' });
+  if (typeof t.class !== 'string' || !classes.has(t.class)) return res.status(400).json({ error: 'invalid class' });
+
+  const newTank = {
+    name: t.name.trim(),
+    nation: t.nation.trim(),
+    br: t.br,
+    armor: t.armor,
+    cannonCaliber: t.cannonCaliber,
+    ammo: t.ammo,
+    crew: t.crew,
+    engineHp: t.engineHp,
+    incline: t.incline,
+    bodyRotation: t.bodyRotation,
+    turretRotation: t.turretRotation,
+    class: t.class
+  };
+  tanks.push(newTank);
+  await saveTanks();
   res.json({ success: true });
 });
 


### PR DESCRIPTION
## Summary
- Add extensive tank form fields with sliders, ammo checkboxes and class dropdown in admin UI
- Send new tank attributes from client to server
- Validate and persist tank configurations to `data/tanks.json`, including setup script

## Testing
- `npm test`
- `npm run setup`
- `node tanksfornothing-server.js` (startup check)


------
https://chatgpt.com/codex/tasks/task_e_68ac0b53e73c832887f546af046e56e6