### PR TITLE
feat: allow CRUD nations and link ammo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal browser-based multiplayer tank demo built with Node.js, Express, Socke
 - WASD driving, mouse-look turret control
 - Hold `C` for freelook, `V` to toggle first/third person
 - Mouse wheel zoom
-- Minimal admin panel for CRUD of tanks, ammo, terrain
+- Minimal admin panel for CRUD of nations, tanks, ammo and terrain
 
 ## Requirements
 - Node.js 18+ and npm
@@ -18,7 +18,7 @@ Run these commands from a terminal (PowerShell on Windows):
 ```bash
 cd tanksfornothing
 npm install
-npm run setup   # create data/tanks.json
+npm run setup   # create data/tanks.json and nations.json
 npm start
 ```
 
@@ -26,7 +26,7 @@ npm start
 ```powershell
 cd tanksfornothing
 npm install
-npm run setup   # create data/tanks.json
+npm run setup   # create data/tanks.json and nations.json
 npm start
 ```
 
@@ -41,10 +41,10 @@ Set `ADMIN_PASSWORD` to change the admin login password (default `adminpass`).
 ## Usage
 - Open `http://localhost:3000` in a modern browser.
 - Click the screen to capture the mouse and drive the tank.
-- Visit `http://localhost:3000/admin/admin.html` for the admin panel. The tank form provides nation and class dropdowns, a BR
-  slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine horsepower sliders, and
-  controls for incline and rotation times. The ammo form captures name, caliber, armor penetration, type, explosion radius and
-  penetration at 0m/100m. Tanks persist across restarts.
+- Visit `http://localhost:3000/admin/admin.html` for the admin panel. Manage nations, then create tanks and ammo tied to those
+  nations. The tank form provides class dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke
+  ammo types, crew and engine horsepower sliders, and controls for incline and rotation times. The ammo form captures name,
+  nation, caliber, armor penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
 
 ## Debugging
 The server logs player connections and updates to the console. Use `npm run dev` to auto-restart on changes.

--- a/admin/admin.html
+++ b/admin/admin.html
@@ -1,6 +1,6 @@
 <!-- admin.html
      Summary: Admin dashboard for Tanks for Nothing.
-     Structure: login view and CRUD forms for tanks, ammo, terrain.
+     Structure: login view and CRUD forms for nations, tanks, ammo, terrain.
      Usage: Navigate to /admin/admin.html in browser. -->
 <!DOCTYPE html>
 <html lang="en">
@@ -32,14 +32,15 @@
   </div>
 
   <div id="dashboard" style="display:none">
+    <h2>Nations</h2>
+    <div id="nationList"></div>
+    <input id="nationName" placeholder="Name">
+    <button id="addNationBtn">Add Nation</button>
+
     <h2>Tanks</h2>
     <div id="tankList"></div>
     <input id="tankName" placeholder="Name">
-    <select id="tankNation">
-      <option value="Germany">Germany</option>
-      <option value="UK">UK</option>
-      <option value="USA">USA</option>
-    </select>
+    <select id="tankNation"></select>
     <label>Battle Rating
       <input id="tankBR" type="range" min="1" max="10" step="0.1" oninput="document.getElementById('brVal').innerText=this.value">
       <span id="brVal"></span>
@@ -88,6 +89,7 @@
     <h2>Ammo</h2>
     <div id="ammoList"></div>
     <input id="ammoName" placeholder="Name">
+    <select id="ammoNation"></select>
     <label>Caliber (mm)
       <input id="ammoCaliber" type="range" min="20" max="150" step="10" oninput="document.getElementById('ammoCaliberVal').innerText=this.value">
       <span id="ammoCaliberVal"></span>

--- a/data/nations.json
+++ b/data/nations.json
@@ -1,0 +1,8 @@
+{
+  "_comment": [
+    "Summary: Persisted nation names for Tanks for Nothing.",
+    "Structure: JSON object with _comment array and nations list.",
+    "Usage: Managed automatically by server; do not edit manually."
+  ],
+  "nations": []
+}

--- a/scripts/init-data.js
+++ b/scripts/init-data.js
@@ -1,20 +1,22 @@
 // init-data.js
-// Summary: Ensures data directory and tanks.json exist for persistence.
-// Structure: create data folder -> write default tanks.json if missing.
+// Summary: Ensures data directory plus tanks.json and nations.json exist for persistence.
+// Structure: create data folder -> write default tanks.json and nations.json if missing.
 // Usage: Run with `node scripts/init-data.js` prior to starting server.
 // ---------------------------------------------------------------------------
 
 import { promises as fs } from 'fs';
 const dataDir = new URL('../data/', import.meta.url);
-const dataFile = new URL('tanks.json', dataDir);
+const tanksFile = new URL('tanks.json', dataDir);
+const nationsFile = new URL('nations.json', dataDir);
 
 async function init() {
   await fs.mkdir(dataDir, { recursive: true });
+  // Ensure tanks.json exists
   try {
-    await fs.access(dataFile);
+    await fs.access(tanksFile);
     console.log('tanks.json already exists');
   } catch {
-    const data = {
+    const tanksData = {
       _comment: [
         'Summary: Persisted tank definitions for Tanks for Nothing.',
         'Structure: JSON object with _comment array and tanks list.',
@@ -22,8 +24,25 @@ async function init() {
       ],
       tanks: []
     };
-    await fs.writeFile(dataFile, JSON.stringify(data, null, 2));
+    await fs.writeFile(tanksFile, JSON.stringify(tanksData, null, 2));
     console.log('Created data/tanks.json');
+  }
+
+  // Ensure nations.json exists
+  try {
+    await fs.access(nationsFile);
+    console.log('nations.json already exists');
+  } catch {
+    const nationsData = {
+      _comment: [
+        'Summary: Persisted nation names for Tanks for Nothing.',
+        'Structure: JSON object with _comment array and nations list.',
+        'Usage: Managed automatically by server; do not edit manually.'
+      ],
+      nations: []
+    };
+    await fs.writeFile(nationsFile, JSON.stringify(nationsData, null, 2));
+    console.log('Created data/nations.json');
   }
 }
 


### PR DESCRIPTION
## Summary
- add nations.json with server persistence and CRUD endpoints
- hook admin panel into dynamic nation list for tanks and ammo
- document nation setup and ensure init script writes nations file

## Testing
- `npm run setup`
- `node --check tanksfornothing-server.js`
- `node --check admin/admin.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1188031c8328a9dd18649686fc79