### PR TITLE
style: stack CRUD fields and apply tank theme

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,26 +1,55 @@
 /* admin.css
-   Summary: Styling for Tanks admin dashboard.
+   Summary: Styling for Tanks admin dashboard with tank-themed cards and forms.
    Structure: grid layout, cards and chart container for statistics.
    Usage: Linked by admin.html for admin panel styling. */
+
+/* The admin dashboard is laid out with a grid of cards on a themed
+   military background. Cards host the CRUD forms; each form element is
+   block-level for clarity and vertical alignment. */
 
 #dashboard {
   padding: 60px 20px 20px;
 }
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
 }
+
 .card {
-  background: #fff;
+  background: #3e4b2e; /* dark olive befitting tank theme */
+  color: #f5f5f5;
   padding: 20px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  border: 1px solid #2b361e;
 }
+
 .instructions {
   margin-bottom: 20px;
 }
+
 .chart-container {
   position: relative;
   height: 200px;
+}
+
+/* Ensure each form control sits on its own line for readability */
+
+.card input:not([type="checkbox"]),
+.card select,
+.card button,
+.card label,
+.card .checkbox-group {
+  display: block;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+/* Checkbox groups list ammo types vertically */
+.card .checkbox-group label {
+  display: block;
+  width: auto;
+  margin-bottom: 4px;
 }

--- a/admin/admin.html
+++ b/admin/admin.html
@@ -72,7 +72,8 @@
           <input id="tankCaliber" type="range" min="20" max="150" step="10" oninput="document.getElementById('caliberVal').innerText=this.value">
           <span id="caliberVal"></span>
         </label>
-        <div>
+        <!-- Ammo type checkboxes displayed vertically -->
+        <div class="checkbox-group">
           <label><input type="checkbox" name="tankAmmo" value="HE"> HE</label>
           <label><input type="checkbox" name="tankAmmo" value="HEAT"> HEAT</label>
           <label><input type="checkbox" name="tankAmmo" value="AP"> AP</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,10 +1,40 @@
 /* styles.css
-   Summary: Basic styling for Tanks for Nothing client and admin pages.
+   Summary: Basic styling for Tanks for Nothing client and admin pages with a tank-inspired palette.
    Structure: Layout, navbar, overlay instructions.
    Usage: Included automatically by HTML pages. */
-body { margin: 0; overflow: hidden; font-family: Arial, sans-serif; }
-#navbar { position: fixed; top: 0; left: 0; right: 0; background: #222; color: #fff; padding: 8px; }
-#instructions { position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.5); color: #fff; padding: 5px 10px; border-radius: 4px; font-size: 14px; }
+/* Global body and navbar styling with a dark, tank-inspired palette */
+body {
+  margin: 0;
+  overflow: hidden;
+  font-family: "Trebuchet MS", Arial, sans-serif;
+  background: #2b331f; /* muted military green */
+  color: #e0e0e0;
+}
+
+#navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #3e4b2e; /* darker green for contrast */
+  color: #fff;
+  padding: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+#instructions {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(34,34,34,0.8);
+  color: #fff;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  border: 1px solid #2b2b2b;
+}
+
 canvas { display: block; }
 
 /* Admin navbar profile menu */


### PR DESCRIPTION
## Summary
- display tank and ammo CRUD fields on separate lines
- apply tank-themed dark styling for admin cards and global page palette

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1e3f1aa48328873b1ecfcae21e0e