### PR TITLE
Add terrain management and restart system

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -1,6 +1,6 @@
 <!-- admin.html
-     Summary: Admin dashboard for Tanks for Nothing.
-     Structure: login view and CRUD forms for nations, tanks, ammo, terrain.
+     Summary: Admin dashboard for Tanks for Nothing with management forms and game restart controls.
+     Structure: login view and CRUD forms for nations, tanks, ammo and terrain, plus restart button.
      Usage: Navigate to /admin/admin.html in browser. -->
 <!DOCTYPE html>
 <html lang="en">
@@ -138,9 +138,11 @@
 
       <section class="card">
         <h2>Terrain</h2>
-        <div id="terrainName"></div>
-        <input id="terrainInput" placeholder="Terrain name">
-        <button id="setTerrainBtn">Set Terrain</button>
+        <p class="instructions">Select a terrain then restart the game to apply.</p>
+        <div id="terrainList"></div>
+        <input id="terrainName" placeholder="Name">
+        <button id="addTerrainBtn">Add Terrain</button>
+        <button id="restartBtn">Restart Game</button>
       </section>
     </div>
   </div>

--- a/data/terrains.json
+++ b/data/terrains.json
@@ -1,0 +1,9 @@
+{
+  "_comment": [
+    "Summary: Persisted terrain names and selected index for Tanks for Nothing.",
+    "Structure: JSON object with _comment array, current index and terrains list.",
+    "Usage: Managed automatically by server; do not edit manually."
+  ],
+  "current": 0,
+  "terrains": ["flat"]
+}


### PR DESCRIPTION
## Summary
- Allow admins to manage terrain presets and restart the game with a chosen terrain
- Persist terrain selections server-side and broadcast changes to clients
- Rebuild client terrain geometry when the server selects a new terrain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1f94327083289c0732dab00a54b8