### PR TITLE
feat: split admin panel into sidebar pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Set `ADMIN_PASSWORD` to change the admin login password (default `adminpass`).
 ## Usage
 - Open `http://localhost:3000` in a modern browser.
 - Click the screen to capture the mouse and drive the tank.
-- Visit `http://localhost:3000/admin/admin.html` for the admin panel. Manage nations, then create tanks and ammo tied to those
-  nations. The tank form provides class dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke
-  ammo types, crew and engine horsepower sliders, and controls for incline and rotation times. The ammo form captures name,
-  nation, caliber, armor penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
+- Visit `http://localhost:3000/admin/admin.html` for the admin dashboard. A sidebar links to dedicated pages for Nations, Tanks,
+  Ammo, Terrain and Game Settings. Manage nations, then create tanks and ammo tied to those nations. The tank form provides class
+  dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine
+  horsepower sliders, and controls for incline and rotation times. The ammo form captures name, nation, caliber, armor
+  penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
 
 ## Debugging
 The server logs player connections and updates to the console. Use `npm run dev` to auto-restart on changes.

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,20 +1,34 @@
 /* admin.css
-   Summary: Styling for Tanks admin dashboard with tank-themed cards and forms.
-   Structure: grid layout, cards and chart container for statistics.
-   Usage: Linked by admin.html for admin panel styling. */
+   Summary: Styling for Tanks admin pages with tank-themed cards, forms and sidebar navigation.
+   Structure: flex layout with sidebar, reusable card styles and chart container for statistics.
+   Usage: Linked by all files in /admin for admin panel styling. */
 
-/* The admin dashboard is laid out with a grid of cards on a themed
-   military background. Cards host the CRUD forms; each form element is
-   block-level for clarity and vertical alignment. */
+/* Admin pages use a clean flex layout with a sidebar and card-style forms.
+   Each form element is block-level for clarity and vertical alignment. */
 
-#dashboard {
-  padding: 60px 20px 20px;
+#app {
+  padding-top: 60px;
+  display: flex;
+  min-height: calc(100vh - 60px);
 }
 
-.dashboard-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
+#sidebar {
+  width: 200px;
+  background: #2b361e;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+#sidebar a {
+  color: #f5f5f5;
+  text-decoration: none;
+  margin-bottom: 10px;
+}
+
+#mainContent {
+  flex: 1;
+  padding: 20px;
 }
 
 .card {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,8 +1,9 @@
 // admin.js
-// Summary: Handles admin login and CRUD actions for nations, tanks, ammo and terrain.
+// Summary: Handles admin login and CRUD actions for nations, tanks, ammo and terrain across
+//          separate admin pages linked by a sidebar.
 // Uses secure httpOnly cookie set by server and provides logout and game restart endpoints.
 // Structure: auth helpers -> data loaders -> CRUD functions -> restart helpers -> UI handlers.
-// Usage: Included by admin.html.
+// Usage: Included by all files in /admin.
 // ---------------------------------------------------------------------------
 
 function toggleMenu() {
@@ -23,14 +24,15 @@ async function login() {
   });
   console.debug('Admin login response', res.status);
   if (res.ok) {
-    // Cookie is set server-side; simply render dashboard
-    showDashboard();
+    // Cookie is set server-side; render the page
+    showApp();
   } else alert('Login failed');
 }
 
-function showDashboard() {
+function showApp() {
   document.getElementById('login').style.display = 'none';
-  document.getElementById('dashboard').style.display = 'block';
+  const app = document.getElementById('app');
+  if (app) app.style.display = 'flex';
   loadData();
 }
 
@@ -56,42 +58,52 @@ async function loadData() {
 
   // Populate nation selects for tank and ammo forms
   const nationOptions = nationsCache.map(n => `<option value="${n}">${n}</option>`).join('');
-  document.getElementById('tankNation').innerHTML = nationOptions;
-  document.getElementById('ammoNation').innerHTML = nationOptions;
+  const tankNation = document.getElementById('tankNation');
+  if (tankNation) tankNation.innerHTML = nationOptions;
+  const ammoNation = document.getElementById('ammoNation');
+  if (ammoNation) ammoNation.innerHTML = nationOptions;
 
   // Render nation list
   const nationDiv = document.getElementById('nationList');
-  nationDiv.innerHTML = nationsCache.map((n, i) =>
-    `<div>${n} <button data-i="${i}" class="edit-nation">Edit</button><button data-i="${i}" class="del-nation">Delete</button></div>`
-  ).join('');
-  nationDiv.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
-  nationDiv.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
+  if (nationDiv) {
+    nationDiv.innerHTML = nationsCache.map((n, i) =>
+      `<div>${n} <button data-i="${i}" class="edit-nation">Edit</button><button data-i="${i}" class="del-nation">Delete</button></div>`
+    ).join('');
+    nationDiv.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
+    nationDiv.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
+  }
 
   const tankDiv = document.getElementById('tankList');
-  tankDiv.innerHTML = tanksCache.map((t, i) =>
-    `<div>${t.name} (${t.nation}) BR ${t.br} <button data-i="${i}" class="edit-tank">Edit</button><button data-i="${i}" class="del-tank">Delete</button></div>`
-  ).join('');
-  tankDiv.querySelectorAll('.edit-tank').forEach(btn => btn.addEventListener('click', () => editTank(btn.dataset.i)));
-  tankDiv.querySelectorAll('.del-tank').forEach(btn => btn.addEventListener('click', () => deleteTank(btn.dataset.i)));
+  if (tankDiv) {
+    tankDiv.innerHTML = tanksCache.map((t, i) =>
+      `<div>${t.name} (${t.nation}) BR ${t.br} <button data-i="${i}" class="edit-tank">Edit</button><button data-i="${i}" class="del-tank">Delete</button></div>`
+    ).join('');
+    tankDiv.querySelectorAll('.edit-tank').forEach(btn => btn.addEventListener('click', () => editTank(btn.dataset.i)));
+    tankDiv.querySelectorAll('.del-tank').forEach(btn => btn.addEventListener('click', () => deleteTank(btn.dataset.i)));
+  }
 
   const ammoDiv = document.getElementById('ammoList');
-  ammoDiv.innerHTML = ammoCache.map((a, i) =>
-    `<div>${a.name} (${a.nation} - ${a.type}) <button data-i="${i}" class="edit-ammo">Edit</button><button data-i="${i}" class="del-ammo">Delete</button></div>`
-  ).join('');
-  ammoDiv.querySelectorAll('.edit-ammo').forEach(btn => btn.addEventListener('click', () => editAmmo(btn.dataset.i)));
-  ammoDiv.querySelectorAll('.del-ammo').forEach(btn => btn.addEventListener('click', () => deleteAmmo(btn.dataset.i)));
+  if (ammoDiv) {
+    ammoDiv.innerHTML = ammoCache.map((a, i) =>
+      `<div>${a.name} (${a.nation} - ${a.type}) <button data-i="${i}" class="edit-ammo">Edit</button><button data-i="${i}" class="del-ammo">Delete</button></div>`
+    ).join('');
+    ammoDiv.querySelectorAll('.edit-ammo').forEach(btn => btn.addEventListener('click', () => editAmmo(btn.dataset.i)));
+    ammoDiv.querySelectorAll('.del-ammo').forEach(btn => btn.addEventListener('click', () => deleteAmmo(btn.dataset.i)));
+  }
 
   const terrainDiv = document.getElementById('terrainList');
-  terrainDiv.innerHTML = terrainsCache.map((t, i) =>
-    `<div><input type="radio" name="terrainRadio" value="${i}" ${i == currentTerrainIndex ? 'checked' : ''}> ${t} <button data-i="${i}" class="edit-terrain">Edit</button><button data-i="${i}" class="del-terrain">Delete</button></div>`
-  ).join('');
-  terrainDiv.querySelectorAll('.edit-terrain').forEach(btn => btn.addEventListener('click', () => editTerrain(btn.dataset.i)));
-  terrainDiv.querySelectorAll('.del-terrain').forEach(btn => btn.addEventListener('click', () => deleteTerrain(btn.dataset.i)));
+  if (terrainDiv) {
+    terrainDiv.innerHTML = terrainsCache.map((t, i) =>
+      `<div><input type="radio" name="terrainRadio" value="${i}" ${i == currentTerrainIndex ? 'checked' : ''}> ${t} <button data-i="${i}" class="edit-terrain">Edit</button><button data-i="${i}" class="del-terrain">Delete</button></div>`
+    ).join('');
+    terrainDiv.querySelectorAll('.edit-terrain').forEach(btn => btn.addEventListener('click', () => editTerrain(btn.dataset.i)));
+    terrainDiv.querySelectorAll('.del-terrain').forEach(btn => btn.addEventListener('click', () => deleteTerrain(btn.dataset.i)));
+  }
 
-  clearNationForm();
-  clearTankForm();
-  clearAmmoForm();
-  clearTerrainForm();
+  if (document.getElementById('nationName')) clearNationForm();
+  if (document.getElementById('tankName')) clearTankForm();
+  if (document.getElementById('ammoName')) clearAmmoForm();
+  if (document.getElementById('terrainName')) clearTerrainForm();
   updateStats();
 }
 
@@ -307,10 +319,13 @@ async function restartGame() {
 }
 
 function updateStats() {
+  const summary = document.getElementById('summaryStats');
+  const chartEl = document.getElementById('tankNationChart');
+  if (!summary || !chartEl) return; // not on dashboard page
   const totalNations = nationsCache.length;
   const totalTanks = tanksCache.length;
-  document.getElementById('summaryStats').innerText = `${totalNations} nations, ${totalTanks} tanks`;
-  const ctx = document.getElementById('tankNationChart').getContext('2d');
+  summary.innerText = `${totalNations} nations, ${totalTanks} tanks`;
+  const ctx = chartEl.getContext('2d');
   const counts = nationsCache.map(n => tanksCache.filter(t => t.nation === n).length);
   if (tankNationChart) tankNationChart.destroy();
   tankNationChart = new Chart(ctx, {
@@ -330,22 +345,30 @@ function updateStats() {
   });
 }
 
-// Attach event listeners to expose functions in module scope
-document.getElementById('profilePic').addEventListener('click', toggleMenu);
-document.getElementById('signOutLink').addEventListener('click', (e) => {
+// Attach event listeners conditionally so pages without elements do not error
+const profilePic = document.getElementById('profilePic');
+if (profilePic) profilePic.addEventListener('click', toggleMenu);
+const signOutLink = document.getElementById('signOutLink');
+if (signOutLink) signOutLink.addEventListener('click', (e) => {
   e.preventDefault();
   signOut();
 });
-document.getElementById('loginBtn').addEventListener('click', login);
-document.getElementById('addNationBtn').addEventListener('click', addNation);
-document.getElementById('addTankBtn').addEventListener('click', addTank);
-document.getElementById('addAmmoBtn').addEventListener('click', addAmmo);
-document.getElementById('addTerrainBtn').addEventListener('click', addTerrain);
-document.getElementById('restartBtn').addEventListener('click', restartGame);
+const loginBtn = document.getElementById('loginBtn');
+if (loginBtn) loginBtn.addEventListener('click', login);
+const addNationBtn = document.getElementById('addNationBtn');
+if (addNationBtn) addNationBtn.addEventListener('click', addNation);
+const addTankBtn = document.getElementById('addTankBtn');
+if (addTankBtn) addTankBtn.addEventListener('click', addTank);
+const addAmmoBtn = document.getElementById('addAmmoBtn');
+if (addAmmoBtn) addAmmoBtn.addEventListener('click', addAmmo);
+const addTerrainBtn = document.getElementById('addTerrainBtn');
+if (addTerrainBtn) addTerrainBtn.addEventListener('click', addTerrain);
+const restartBtn = document.getElementById('restartBtn');
+if (restartBtn) restartBtn.addEventListener('click', restartGame);
 
 // Check on load if admin cookie is present via server endpoint
 async function checkAdmin() {
   const res = await fetch('/admin/status');
-  if (res.ok) showDashboard();
+  if (res.ok) showApp();
 }
 checkAdmin();

--- a/admin/ammo.html
+++ b/admin/ammo.html
@@ -1,0 +1,84 @@
+<!-- ammo.html
+     Summary: Admin page for creating and editing ammunition.
+     Structure: login, navbar with profile menu, sidebar navigation and ammo CRUD card.
+     Usage: Visit /admin/ammo.html after logging in. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Manage Ammo</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="admin.css">
+</head>
+<body>
+  <nav id="navbar">
+    <span>Admin Panel</span>
+    <div class="profile-menu" id="profileMenu">
+      <img src="https://placehold.co/32" alt="profile" id="profilePic" />
+      <div class="profile-menu-content" id="profileMenuContent">
+        <a href="#">Manage Profiles</a>
+        <a href="#">Learning Zone</a>
+        <a href="#">My Details</a>
+        <a href="#">Subscription Details</a>
+        <a href="#">Manage Users</a>
+        <a href="#" id="signOutLink">Sign out</a>
+      </div>
+    </div>
+  </nav>
+
+  <div id="login">
+    <h2>Admin Login</h2>
+    <input type="password" id="password" placeholder="Password">
+    <button id="loginBtn">Login</button>
+  </div>
+
+  <div id="app" style="display:none">
+    <aside id="sidebar">
+      <a href="admin.html">Dashboard</a>
+      <a href="nations.html">Nations</a>
+      <a href="tanks.html">Tanks</a>
+      <a href="ammo.html">Ammo</a>
+      <a href="terrain.html">Terrain</a>
+      <a href="settings.html">Game Settings</a>
+    </aside>
+    <main id="mainContent">
+      <section class="card">
+        <h2>Ammo</h2>
+        <p class="instructions">Manage ammunition statistics.</p>
+        <div id="ammoList"></div>
+        <input id="ammoName" placeholder="Name">
+        <select id="ammoNation"></select>
+        <label>Caliber (mm)
+          <input id="ammoCaliber" type="range" min="20" max="150" step="10" oninput="document.getElementById('ammoCaliberVal').innerText=this.value">
+          <span id="ammoCaliberVal"></span>
+        </label>
+        <label>Armor Penetration (mm)
+          <input id="ammoPen" type="range" min="20" max="160" step="10" oninput="document.getElementById('ammoPenVal').innerText=this.value">
+          <span id="ammoPenVal"></span>
+        </label>
+        <select id="ammoType">
+          <option value="HE">HE</option>
+          <option value="HEAT">HEAT</option>
+          <option value="AP">AP</option>
+          <option value="Smoke">Smoke</option>
+        </select>
+        <label>Explosion Radius (m)
+          <input id="ammoRadius" type="range" min="0" max="20" step="1" oninput="document.getElementById('ammoRadiusVal').innerText=this.value">
+          <span id="ammoRadiusVal"></span>
+        </label>
+        <label>Explosion Penetration 0m (mm)
+          <input id="ammoPen0" type="range" min="20" max="160" step="10" oninput="document.getElementById('ammoPen0Val').innerText=this.value">
+          <span id="ammoPen0Val"></span>
+        </label>
+        <label>Explosion Penetration 100m (mm)
+          <input id="ammoPen100" type="range" min="20" max="160" step="10" oninput="document.getElementById('ammoPen100Val').innerText=this.value">
+          <span id="ammoPen100Val"></span>
+        </label>
+        <button id="addAmmoBtn">Add Ammo</button>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -1,12 +1,12 @@
-<!-- admin.html
-     Summary: Admin dashboard showing overall statistics with sidebar navigation.
-     Structure: login form, persistent navbar with profile menu, sidebar links and dashboard stats card.
-     Usage: Visit /admin/admin.html after login to view statistics. Use sidebar for other admin pages. -->
+<!-- nations.html
+     Summary: Admin page for creating and editing nations.
+     Structure: login, navbar with profile menu, sidebar navigation and nation CRUD card.
+     Usage: Visit /admin/nations.html after logging in. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Tanks Admin Dashboard</title>
+  <title>Manage Nations</title>
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="admin.css">
 </head>
@@ -42,18 +42,16 @@
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">
-      <p class="instructions">Statistics update automatically.</p>
       <section class="card">
-        <h2>Statistics</h2>
-        <p id="summaryStats"></p>
-        <div class="chart-container">
-          <canvas id="tankNationChart" aria-label="Tanks per nation chart"></canvas>
-        </div>
+        <h2>Nations</h2>
+        <p class="instructions">Add, edit or delete nations.</p>
+        <div id="nationList"></div>
+        <input id="nationName" placeholder="Name">
+        <button id="addNationBtn">Add Nation</button>
       </section>
     </main>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/admin/settings.html
+++ b/admin/settings.html
@@ -1,12 +1,12 @@
-<!-- admin.html
-     Summary: Admin dashboard showing overall statistics with sidebar navigation.
-     Structure: login form, persistent navbar with profile menu, sidebar links and dashboard stats card.
-     Usage: Visit /admin/admin.html after login to view statistics. Use sidebar for other admin pages. -->
+<!-- settings.html
+     Summary: Placeholder admin page for future game settings.
+     Structure: login, navbar with profile menu, sidebar navigation and settings card.
+     Usage: Visit /admin/settings.html after logging in. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Tanks Admin Dashboard</title>
+  <title>Game Settings</title>
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="admin.css">
 </head>
@@ -42,18 +42,13 @@
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">
-      <p class="instructions">Statistics update automatically.</p>
       <section class="card">
-        <h2>Statistics</h2>
-        <p id="summaryStats"></p>
-        <div class="chart-container">
-          <canvas id="tankNationChart" aria-label="Tanks per nation chart"></canvas>
-        </div>
+        <h2>Game Settings</h2>
+        <p>Additional configuration options will appear here.</p>
       </section>
     </main>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/admin/tanks.html
+++ b/admin/tanks.html
@@ -1,0 +1,101 @@
+<!-- tanks.html
+     Summary: Admin page for creating and editing tanks.
+     Structure: login, navbar with profile menu, sidebar navigation and tank CRUD card.
+     Usage: Visit /admin/tanks.html after logging in. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Manage Tanks</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="admin.css">
+</head>
+<body>
+  <nav id="navbar">
+    <span>Admin Panel</span>
+    <div class="profile-menu" id="profileMenu">
+      <img src="https://placehold.co/32" alt="profile" id="profilePic" />
+      <div class="profile-menu-content" id="profileMenuContent">
+        <a href="#">Manage Profiles</a>
+        <a href="#">Learning Zone</a>
+        <a href="#">My Details</a>
+        <a href="#">Subscription Details</a>
+        <a href="#">Manage Users</a>
+        <a href="#" id="signOutLink">Sign out</a>
+      </div>
+    </div>
+  </nav>
+
+  <div id="login">
+    <h2>Admin Login</h2>
+    <input type="password" id="password" placeholder="Password">
+    <button id="loginBtn">Login</button>
+  </div>
+
+  <div id="app" style="display:none">
+    <aside id="sidebar">
+      <a href="admin.html">Dashboard</a>
+      <a href="nations.html">Nations</a>
+      <a href="tanks.html">Tanks</a>
+      <a href="ammo.html">Ammo</a>
+      <a href="terrain.html">Terrain</a>
+      <a href="settings.html">Game Settings</a>
+    </aside>
+    <main id="mainContent">
+      <section class="card">
+        <h2>Tanks</h2>
+        <p class="instructions">Create or edit tanks tied to nations.</p>
+        <div id="tankList"></div>
+        <input id="tankName" placeholder="Name">
+        <select id="tankNation"></select>
+        <label>Battle Rating
+          <input id="tankBR" type="range" min="1" max="10" step="0.1" oninput="document.getElementById('brVal').innerText=this.value">
+          <span id="brVal"></span>
+        </label>
+        <select id="tankClass">
+          <option value="Light/Scout">Light/Scout</option>
+          <option value="Medium/MBT">Medium/MBT</option>
+          <option value="Heavy">Heavy</option>
+        </select>
+        <label>Armour Thickness (mm)
+          <input id="tankArmor" type="range" min="10" max="150" step="1" oninput="document.getElementById('armorVal').innerText=this.value">
+          <span id="armorVal"></span>
+        </label>
+        <label>Main Cannon Caliber (mm)
+          <input id="tankCaliber" type="range" min="20" max="150" step="10" oninput="document.getElementById('caliberVal').innerText=this.value">
+          <span id="caliberVal"></span>
+        </label>
+        <div class="checkbox-group">
+          <label><input type="checkbox" name="tankAmmo" value="HE"> HE</label>
+          <label><input type="checkbox" name="tankAmmo" value="HEAT"> HEAT</label>
+          <label><input type="checkbox" name="tankAmmo" value="AP"> AP</label>
+          <label><input type="checkbox" name="tankAmmo" value="Smoke"> Smoke</label>
+        </div>
+        <label>Crew Count
+          <input id="tankCrew" type="range" min="1" max="10" step="1" oninput="document.getElementById('crewVal').innerText=this.value">
+          <span id="crewVal"></span>
+        </label>
+        <label>Engine Horsepower
+          <input id="tankHP" type="range" min="100" max="1000" step="50" oninput="document.getElementById('hpVal').innerText=this.value">
+          <span id="hpVal"></span>
+        </label>
+        <label>Max Incline (%)
+          <input id="tankIncline" type="range" min="2" max="12" step="1" oninput="document.getElementById('inclineVal').innerText=this.value">
+          <span id="inclineVal"></span>
+        </label>
+        <label>Body Rotation Time (s/360°)
+          <input id="tankBodyRot" type="range" min="1" max="60" step="1" oninput="document.getElementById('bodyRotVal').innerText=this.value">
+          <span id="bodyRotVal"></span>
+        </label>
+        <label>Turret Rotation Time (s/360°)
+          <input id="tankTurretRot" type="range" min="1" max="60" step="1" oninput="document.getElementById('turretRotVal').innerText=this.value">
+          <span id="turretRotVal"></span>
+        </label>
+        <button id="addTankBtn">Add Tank</button>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,12 +1,12 @@
-<!-- admin.html
-     Summary: Admin dashboard showing overall statistics with sidebar navigation.
-     Structure: login form, persistent navbar with profile menu, sidebar links and dashboard stats card.
-     Usage: Visit /admin/admin.html after login to view statistics. Use sidebar for other admin pages. -->
+<!-- terrain.html
+     Summary: Admin page for managing terrain presets and restarting the game.
+     Structure: login, navbar with profile menu, sidebar navigation and terrain CRUD card.
+     Usage: Visit /admin/terrain.html after logging in. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Tanks Admin Dashboard</title>
+  <title>Manage Terrain</title>
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="admin.css">
 </head>
@@ -42,18 +42,17 @@
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">
-      <p class="instructions">Statistics update automatically.</p>
       <section class="card">
-        <h2>Statistics</h2>
-        <p id="summaryStats"></p>
-        <div class="chart-container">
-          <canvas id="tankNationChart" aria-label="Tanks per nation chart"></canvas>
-        </div>
+        <h2>Terrain</h2>
+        <p class="instructions">Select a terrain then restart the game to apply.</p>
+        <div id="terrainList"></div>
+        <input id="terrainName" placeholder="Name">
+        <button id="addTerrainBtn">Add Terrain</button>
+        <button id="restartBtn">Restart Game</button>
       </section>
     </main>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <script type="module" src="admin.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add sidebar-driven layout and separate admin pages for dashboard, nations, tanks, ammo, terrain and settings
- update admin script to handle per-page rendering and conditional events
- refresh admin styles for new flex layout and navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac2289e87883289ca4f326a74983c8