### PR TITLE
feat(admin): expand terrain editor with elevation tools

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -6,6 +6,11 @@
 /* Admin pages use a clean flex layout with a sidebar and card-style forms.
    Each form element is block-level for clarity and vertical alignment. */
 
+/* Allow admin pages to scroll while the game view remains fixed */
+body {
+  overflow: auto;
+}
+
 #app {
   padding-top: 60px;
   display: flex;
@@ -73,6 +78,33 @@
   border: 1px solid #2b361e;
   margin-top: 10px;
   cursor: crosshair;
+}
+
+/* Layout for terrain editor controls and previews */
+#editorCard {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+#editorControls {
+  flex: 1;
+  min-width: 220px;
+  max-width: 280px;
+}
+
+#editorViews {
+  flex: 2;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#editorViews canvas,
+#editorViews #terrain3d {
+  width: 100%;
+  height: 300px;
 }
 
 .ground-types button {

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -53,36 +53,56 @@
 
       <section class="card" id="editorCard">
         <h2>Terrain Editor</h2>
-        <p class="instructions">Choose a terrain type and size then paint ground types on the grid.</p>
-        <label for="terrainType">Terrain Type</label>
-        <select id="terrainType">
-          <option value="snow">Snow</option>
-          <option value="jungle">Jungle</option>
-          <option value="desert">Desert</option>
-          <option value="fields">Fields</option>
-        </select>
-        <label for="sizeX">Map width (km)</label>
-        <input type="number" id="sizeX" min="0.1" step="0.1" value="1">
-        <label for="sizeY">Map height (km)</label>
-        <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
-        <button id="generateBtn">Generate Grid</button>
-        <canvas id="terrainCanvas" class="terrain-canvas"></canvas>
+        <p class="instructions">Choose a terrain type and size then paint ground and elevation. Left click raises, right click lowers terrain.</p>
+        <div id="editorControls">
+          <label for="terrainType">Terrain Type</label>
+          <select id="terrainType">
+            <option value="snow">Snow</option>
+            <option value="jungle">Jungle</option>
+            <option value="desert">Desert</option>
+            <option value="fields">Fields</option>
+          </select>
+          <label for="sizeX">Map width (km)</label>
+          <input type="number" id="sizeX" min="0.1" step="0.1" value="1">
+          <label for="sizeY">Map height (km)</label>
+          <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
+          <button id="generateBtn">Generate Grid</button>
 
-        <h3>Ground Types</h3>
-        <div id="groundTypesList" class="ground-types"></div>
-        <label for="groundName">Name</label>
-        <input id="groundName" placeholder="e.g. gravel">
-        <label for="groundColor">Color</label>
-        <input id="groundColor" type="color" value="#777777">
-        <label for="groundTraction">Traction (0-1)</label>
-        <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
-        <label for="groundViscosity">Viscosity (0-1)</label>
-        <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
-        <button id="addGroundBtn">Add Ground Type</button>
+          <label for="mode">Edit Mode</label>
+          <select id="mode">
+            <option value="ground">Ground</option>
+            <option value="elevation">Elevation</option>
+          </select>
+          <label for="brushSize">Brush Size (cells)</label>
+          <input type="number" id="brushSize" min="1" max="10" value="1">
+          <label for="brushShape">Brush Shape</label>
+          <select id="brushShape">
+            <option value="square">Square</option>
+            <option value="circle">Circle</option>
+          </select>
+          <button id="randomizeBtn">Randomize Terrain</button>
+
+          <h3>Ground Types</h3>
+          <div id="groundTypesList" class="ground-types"></div>
+          <label for="groundName">Name</label>
+          <input id="groundName" placeholder="e.g. gravel">
+          <label for="groundColor">Color</label>
+          <input id="groundColor" type="color" value="#777777">
+          <label for="groundTraction">Traction (0-1)</label>
+          <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
+          <label for="groundViscosity">Viscosity (0-1)</label>
+          <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
+          <button id="addGroundBtn">Add Ground Type</button>
+        </div>
+        <div id="editorViews">
+          <canvas id="terrainCanvas" class="terrain-canvas"></canvas>
+          <div id="terrain3d"></div>
+        </div>
       </section>
     </main>
   </div>
 
+  <script src="https://cdn.plot.ly/plotly-2.29.1.min.js"></script>
   <script type="module" src="admin.js"></script>
   <script type="module" src="terrain-editor.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- enable scrolling and responsive layout for admin terrain editor
- add elevation painting with brush tools and random terrain generation
- render terrain colors and heights in a Plotly 3D preview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bc577488328be736c4fe0b0e87c