### PR TITLE
feat: redesign terrain editor workflow

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,5 +1,5 @@
 /* admin.css
-   Summary: Styling for Tanks admin pages with tank-themed cards, forms and sidebar navigation.
+   Summary: Styling for Tanks admin pages with tank-themed cards, forms, sidebar navigation and terrain tables.
    Structure: flex layout with sidebar, reusable card styles and chart container for statistics.
    Usage: Linked by all files in /admin for admin panel styling. */
 
@@ -131,4 +131,25 @@ body {
   padding: 0 2px;
   border-radius: 50%;
   pointer-events: all;
+}
+
+/* Table listing of saved terrains with thumbnail previews */
+#terrainTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+#terrainTable th,
+#terrainTable td {
+  border: 1px solid #2b361e;
+  padding: 4px;
+  text-align: left;
+}
+.terrain-thumb {
+  width: 80px;
+  height: 60px;
+}
+.current-row {
+  outline: 2px solid #fff;
 }

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,6 +1,7 @@
 <!-- terrain.html
      Summary: Admin page for managing terrain presets and interactive terrain editing.
-     Structure: login, navbar with profile menu, sidebar navigation, terrain CRUD card and a grid-based terrain editor.
+     Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
+               and an expandable grid-based terrain editor.
      Usage: Visit /admin/terrain.html after logging in to manage terrains and design custom maps. -->
 <!DOCTYPE html>
 <html lang="en">
@@ -44,17 +45,23 @@
     <main id="mainContent">
       <section class="card">
         <h2>Terrain</h2>
-        <p class="instructions">Select a terrain then restart the game to apply.</p>
-        <div id="terrainList"></div>
-        <input id="terrainName" placeholder="Name">
-        <button id="addTerrainBtn">Add Terrain</button>
+        <p class="instructions">Manage saved maps. Click Add to create a new map or Edit to modify.</p>
+        <button id="newTerrainBtn">Add Map</button>
+        <table id="terrainTable">
+          <thead>
+            <tr><th>Preview</th><th>Type</th><th>Size (km)</th><th>Name</th><th>Actions</th></tr>
+          </thead>
+          <tbody id="terrainList"></tbody>
+        </table>
         <button id="restartBtn">Restart Game</button>
       </section>
 
-      <section class="card" id="editorCard">
+      <section class="card" id="editorCard" style="display:none">
         <h2>Terrain Editor</h2>
-        <p class="instructions">Choose a terrain type and size then paint ground and elevation. Left click raises, right click lowers terrain.</p>
+        <p class="instructions">Fill in map details then paint ground and elevation. Left click raises, right click lowers terrain.</p>
         <div id="editorControls">
+          <label for="terrainName">Name</label>
+          <input id="terrainName" placeholder="Name">
           <label for="terrainType">Terrain Type</label>
           <select id="terrainType">
             <option value="snow">Snow</option>
@@ -93,6 +100,8 @@
           <label for="groundViscosity">Viscosity (0-1)</label>
           <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
           <button id="addGroundBtn">Add Ground Type</button>
+          <button id="saveTerrainBtn">Save Map</button>
+          <button id="cancelEditBtn">Cancel</button>
         </div>
         <div id="editorViews">
           <canvas id="terrainCanvas" class="terrain-canvas"></canvas>

--- a/data/terrains.json
+++ b/data/terrains.json
@@ -1,9 +1,15 @@
 {
   "_comment": [
-    "Summary: Persisted terrain names and selected index for Tanks for Nothing.",
-    "Structure: JSON object with _comment array, current index and terrains list.",
+    "Summary: Persisted terrain details and selected index for Tanks for Nothing.",
+    "Structure: JSON object with _comment array, current index and terrains list of {name,type,size}.",
     "Usage: Managed automatically by server; do not edit manually."
   ],
   "current": 0,
-  "terrains": ["flat"]
+  "terrains": [
+    {
+      "name": "flat",
+      "type": "default",
+      "size": { "x": 1, "y": 1 }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- store terrain metadata (type and size) on the server and expose it via updated CRUD endpoints
- redesign admin terrain page with table of map thumbnails and in-page editor
- style terrain list with table layout and highlight selected map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f773954832887e31b9819be31ae