### PR TITLE
feat: add raised cosine terrain brush

### DIFF
--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -53,7 +53,7 @@
 
       <section class="card" id="editorCard">
         <h2>Terrain Editor</h2>
-        <p class="instructions">Choose a terrain type and size then paint ground and elevation. Left click raises, right click lowers terrain.</p>
+        <p class="instructions">Choose a terrain type and size then paint ground and elevation. Left click raises, right click lowers terrain. Adjust brush X/Y size and peak height for smooth raised-cosine edits.</p>
         <div id="editorControls">
           <label for="terrainType">Terrain Type</label>
           <select id="terrainType">
@@ -73,13 +73,12 @@
             <option value="ground">Ground</option>
             <option value="elevation">Elevation</option>
           </select>
-          <label for="brushSize">Brush Size (cells)</label>
-          <input type="number" id="brushSize" min="1" max="10" value="1">
-          <label for="brushShape">Brush Shape</label>
-          <select id="brushShape">
-            <option value="square">Square</option>
-            <option value="circle">Circle</option>
-          </select>
+          <label for="brushSizeX">Brush Size X (cells)</label>
+          <input type="range" id="brushSizeX" min="1" max="10" value="2">
+          <label for="brushSizeY">Brush Size Y (cells)</label>
+          <input type="range" id="brushSizeY" min="1" max="10" value="2">
+          <label for="brushSizeZ">Brush Height</label>
+          <input type="range" id="brushSizeZ" min="1" max="20" value="5">
           <button id="randomizeBtn">Randomize Terrain</button>
 
           <h3>Ground Types</h3>


### PR DESCRIPTION
## Summary
- add raised-cosine brush with X/Y size and height sliders for smooth elevation edits
- update terrain editor UI to expose brush sliders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac610f755c83289f6a29db68208b2e