### PR TITLE
feat: improve terrain preview controls

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -104,7 +104,8 @@ body {
 #editorViews canvas,
 #editorViews #terrain3d {
   width: 100%;
-  height: 300px;
+  /* enlarged 3D preview for better terrain detail */
+  height: 400px;
 }
 
 .ground-types button {

--- a/admin/terrain-editor.js
+++ b/admin/terrain-editor.js
@@ -1,8 +1,8 @@
 // terrain-editor.js
-// Summary: Enhanced terrain editor with raised-cosine elevation brush and 3D preview.
+// Summary: Enhanced terrain editor with raised-cosine elevation brush, proportional 3D preview and axis toggle.
 // Structure: state setup -> ground type management -> grid generation -> drawing -> raised-cosine painting -> 3D plot -> event wiring.
 // Usage: Imported by terrain.html; provides smooth terrain sculpting with adjustable X/Y size and peak height sliders. Axes in the
-//         3D preview are measured in metres with a fixed 50 m grid spacing for clarity.
+//         3D preview are measured in metres with a fixed 50 m grid spacing and can be hidden for a clean view.
 
 // Default ground types with color, traction and viscosity for quick start
 const defaultGroundTypes = [
@@ -184,12 +184,16 @@ function update3DPlot() {
   ]);
   const xCoords = Array.from({ length: gridWidth }, (_, i) => i * cellMeters);
   const yCoords = Array.from({ length: gridHeight }, (_, i) => i * cellMeters);
+  const showAxes = document.getElementById('showAxes').checked; // user toggle for axis visibility
   const layout = {
     margin: { l: 0, r: 0, t: 0, b: 0 },
     scene: {
-      xaxis: { title: 'X (m)', range: [0, mapWidthMeters], dtick: cellMeters },
-      yaxis: { title: 'Y (m)', range: [0, mapHeightMeters], dtick: cellMeters },
-      zaxis: { title: 'Elevation (m)', range: [0, maxHeight], dtick: cellMeters }
+      // Axes use metres so setting aspectmode:'data' keeps proportions realistic
+      xaxis: { title: 'X (m)', range: [0, mapWidthMeters], dtick: cellMeters, visible: showAxes },
+      yaxis: { title: 'Y (m)', range: [0, mapHeightMeters], dtick: cellMeters, visible: showAxes },
+      zaxis: { title: 'Elevation (m)', range: [0, maxHeight], dtick: cellMeters, visible: showAxes },
+      aspectmode: 'data',
+      camera: { eye: { x: 0, y: 0, z: 2 }, projection: { type: 'orthographic' } }
     }
   };
   Plotly.newPlot('terrain3d', [{
@@ -210,6 +214,7 @@ renderGroundTypes();
 document.getElementById('addGroundBtn').addEventListener('click', addGroundType);
 document.getElementById('generateBtn').addEventListener('click', generateGrid);
 document.getElementById('randomizeBtn').addEventListener('click', randomizeTerrain);
+document.getElementById('showAxes').addEventListener('change', update3DPlot);
 
 let mouseDown = false;
 canvas.addEventListener('mousedown', (e) => { mouseDown = true; handlePaint(e); });

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -88,6 +88,9 @@
           <input type="range" id="brushSizeZ" min="1" max="20" value="5">
           <button id="randomizeBtn">Randomize Terrain</button>
 
+          <label for="showAxes">Show Axes</label>
+          <input type="checkbox" id="showAxes" checked>
+
           <h3>Ground Types</h3>
           <div id="groundTypesList" class="ground-types"></div>
           <label for="groundName">Name</label>


### PR DESCRIPTION
## Summary
- scale 3D terrain preview with equal units for x, y and z and use orthographic top view
- add a Show Axes checkbox to hide axis lines and labels in the editor
- enlarge 3D preview area for better detail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac99b02024832899c73ab597afab26