### PR TITLE
fix terrain editor grid interactions

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -101,7 +101,10 @@ body {
   gap: 10px;
 }
 
-#editorViews canvas,
+#editorViews canvas {
+  /* allow JS to control exact pixel size; prevent blurriness */
+  image-rendering: pixelated;
+}
 #editorViews #terrain3d {
   width: 100%;
   /* enlarged 3D preview for better terrain detail */


### PR DESCRIPTION
## Summary
- ensure terrain editor canvas uses exact pixel dimensions for square grid cells
- scale mouse coordinates and block event propagation so editing the grid no longer rotates the 3D preview
- adjust admin styles to let JavaScript dictate canvas size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aca3ba8ddc832896bb45cad847cca8