### PR TITLE
feat: enable direct 3D terrain sculpting

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,5 +1,5 @@
 /* admin.css
-   Summary: Styling for Tanks admin pages with tank-themed cards, forms, sidebar navigation and terrain tables.
+   Summary: Styling for Tanks admin pages with tank-themed cards, forms, sidebar navigation, terrain tables and 3D terrain editor layout.
    Structure: flex layout with sidebar, reusable card styles and chart container for statistics.
    Usage: Linked by all files in /admin for admin panel styling. */
 
@@ -73,13 +73,6 @@ body {
   margin-bottom: 4px;
 }
 
-/* Terrain editor specific styling */
-.terrain-canvas {
-  border: 1px solid #2b361e;
-  margin-top: 10px;
-  cursor: crosshair;
-}
-
 /* Layout for terrain editor controls and previews */
 #editorCard {
   display: flex;
@@ -99,11 +92,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-#editorViews canvas {
-  /* allow JS to control exact pixel size; prevent blurriness */
-  image-rendering: pixelated;
 }
 #editorViews #terrain3d {
   width: 100%;

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,7 +1,8 @@
 <!-- terrain.html
-     Summary: Admin page for managing terrain presets and interactive terrain editing.
+     Summary: Admin page for managing terrain presets with a direct 3D terrain editor that allows
+              clicking on the surface to sculpt ground types and elevation.
      Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
-               and an expandable grid-based terrain editor.
+               and an expandable 3D editor featuring camera controls and shading.
      Usage: Visit /admin/terrain.html after logging in to manage terrains and design custom maps. -->
 <!DOCTYPE html>
 <html lang="en">
@@ -91,6 +92,21 @@
           <label for="showAxes">Show Axes</label>
           <input type="checkbox" id="showAxes" checked>
 
+          <label for="viewSelect">View</label>
+          <select id="viewSelect">
+            <option value="iso">Isometric</option>
+            <option value="top">Top</option>
+            <option value="front">Front</option>
+            <option value="side">Side</option>
+          </select>
+          <label for="projectionType">Projection</label>
+          <select id="projectionType">
+            <option value="perspective">Perspective</option>
+            <option value="orthographic">Orthographic</option>
+          </select>
+          <label for="lockCamera">Lock Position</label>
+          <input type="checkbox" id="lockCamera">
+
           <h3>Ground Types</h3>
           <div id="groundTypesList" class="ground-types"></div>
           <label for="groundName">Name</label>
@@ -106,7 +122,6 @@
           <button id="cancelEditBtn">Cancel</button>
         </div>
         <div id="editorViews">
-          <canvas id="terrainCanvas" class="terrain-canvas"></canvas>
           <div id="terrain3d"></div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- allow direct ground and elevation painting by clicking the 3D chart
- add view presets, projection choice, camera lock, and lighting for better terrain previews
- clean up legacy grid canvas and related styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aca5d673608328896c6627ce3b44b9