### PR TITLE
feat: auto render terrain preview

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -315,6 +315,7 @@ function openTerrainEditor(i) {
     document.getElementById('sizeY').value = t.size.y;
     document.getElementById('saveTerrainBtn').innerText = 'Update Terrain';
   }
+  document.dispatchEvent(new Event('terrain-editor-opened'));
 }
 
 async function deleteTerrain(i) {

--- a/admin/terrain-editor.js
+++ b/admin/terrain-editor.js
@@ -1,7 +1,7 @@
 // terrain-editor.js
 // Summary: Terrain editor enabling direct 3D surface sculpting with a raised-cosine brush, camera presets,
 //          perspective control and shading.
-// Structure: state setup -> ground type management -> grid generation -> raised-cosine painting -> 3D plot with camera controls -> event wiring.
+// Structure: state setup -> ground type management -> terrain initialization -> raised-cosine painting -> 3D plot with camera controls -> event wiring.
 // Usage: Imported by terrain.html; click or drag on the 3D plot to paint ground or elevation. Axes and camera settings are user configurable.
 
 // Default ground types with color, traction and viscosity for quick start
@@ -70,8 +70,8 @@ function addGroundType() {
   renderGroundTypes();
 }
 
-// Generate grid based on map size in km (1 cell = 50 m)
-function generateGrid() {
+// Initialize terrain based on map size in km (1 cell = 50 m)
+function initializeTerrain() {
   const type = document.getElementById('terrainType').value;
   const xKm = Number(document.getElementById('sizeX').value);
   const yKm = Number(document.getElementById('sizeY').value);
@@ -81,7 +81,7 @@ function generateGrid() {
   gridHeight = Math.max(1, Math.round(yMeters / cellMeters));
   mapWidthMeters = gridWidth * cellMeters;
   mapHeightMeters = gridHeight * cellMeters;
-  console.debug('Generating grid', { type, gridWidth, gridHeight, mapWidthMeters, mapHeightMeters });
+  console.debug('Initializing terrain', { type, gridWidth, gridHeight, mapWidthMeters, mapHeightMeters });
   groundGrid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(currentGround));
   elevationGrid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(0));
   update3DPlot();
@@ -192,12 +192,16 @@ function update3DPlot() {
 // Event wiring
 renderGroundTypes();
 document.getElementById('addGroundBtn').addEventListener('click', addGroundType);
-document.getElementById('generateBtn').addEventListener('click', generateGrid);
 document.getElementById('randomizeBtn').addEventListener('click', randomizeTerrain);
 document.getElementById('showAxes').addEventListener('change', update3DPlot);
 document.getElementById('viewSelect').addEventListener('change', update3DPlot);
 document.getElementById('projectionType').addEventListener('change', update3DPlot);
 document.getElementById('lockCamera').addEventListener('change', update3DPlot);
+['sizeX','sizeY','terrainType'].forEach(id => {
+  const el = document.getElementById(id);
+  el.addEventListener('change', initializeTerrain);
+});
+document.addEventListener('terrain-editor-opened', initializeTerrain);
 
 const plot = document.getElementById('terrain3d');
 let mouseDown = false;

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,6 +1,7 @@
 <!-- terrain.html
      Summary: Admin page for managing terrain presets with a direct 3D terrain editor that allows
-              clicking on the surface to sculpt ground types and elevation.
+              clicking on the surface to sculpt ground types and elevation. The 3D view renders
+              automatically whenever a map is created or its size/type is changed.
      Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
                and an expandable 3D editor featuring camera controls and shading.
      Usage: Visit /admin/terrain.html after logging in to manage terrains and design custom maps. -->
@@ -61,6 +62,7 @@
         <h2>Terrain Editor</h2>
 
         <div id="editorControls">
+          <p class="instructions">Map preview updates automatically when size or terrain type changes.</p>
           <label for="terrainName">Name</label>
           <input id="terrainName" placeholder="Name">
           <label for="terrainType">Terrain Type</label>
@@ -74,7 +76,6 @@
           <input type="number" id="sizeX" min="0.1" step="0.1" value="1">
           <label for="sizeY">Map height (km)</label>
           <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
-          <button id="generateBtn">Generate Grid</button>
 
           <label for="mode">Edit Mode</label>
           <select id="mode">


### PR DESCRIPTION
## Summary
- remove outdated grid button from terrain editor and show instructions for auto-updating map preview
- initialize terrain and 3D preview automatically when editing or adjusting map settings
- trigger terrain initialization from admin panel when opening the editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb8f0a2dc8328a04056e1e711f932