### PR TITLE
feat: add lobby tank selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,8 @@
 <!-- index.html
-     Summary: Client entry page for Tanks for Nothing.
-     Structure: basic UI with canvas for Three.js rendering and overlay for controls.
-     Usage: Open in browser; click to capture mouse and play. -->
+     Summary: Client entry and lobby page for Tanks for Nothing.
+     Structure: includes lobby selection UI then canvas for Three.js rendering and
+                overlay for controls.
+     Usage: Open in browser, choose nation and tank, then click Join to play. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,7 +12,16 @@
 </head>
 <body>
   <nav id="navbar"><span>Tanks for Nothing</span></nav>
-  <div id="instructions">WASD move | Space brake | Mouse look | C freelook | V camera | Scroll zoom | 1-4 ammo</div>
+  <div id="lobby">
+    <p>Select your nation and tank to join the battle.</p>
+    <label for="nationSelect">Nation:</label>
+    <select id="nationSelect"></select>
+    <label for="tankSelect">Tank:</label>
+    <select id="tankSelect"></select>
+    <button id="joinBtn">Join</button>
+    <div id="lobbyError"></div>
+  </div>
+  <div id="instructions" style="display:none">WASD move | Space brake | Mouse look | C freelook | V camera | Scroll zoom | 1-4 ammo</div>
   <script src="/socket.io/socket.io.js"></script>
   <script
     type="module"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,6 @@
 /* styles.css
    Summary: Basic styling for Tanks for Nothing client and admin pages with a tank-inspired palette.
-   Structure: Layout, navbar, overlay instructions.
+   Structure: Layout, navbar, lobby overlay and instructions.
    Usage: Included automatically by HTML pages. */
 /* Global body and navbar styling with a dark, tank-inspired palette */
 body {
@@ -20,6 +20,28 @@ body {
   color: #fff;
   padding: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+#lobby {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(34,34,34,0.9);
+  padding: 20px;
+  border-radius: 6px;
+  text-align: center;
+  z-index: 1000;
+}
+
+#lobby select,
+#lobby button {
+  margin: 5px;
+}
+
+#lobbyError {
+  color: #ff8080;
+  margin-top: 5px;
 }
 
 #instructions {


### PR DESCRIPTION
## Summary
- add lobby UI to choose nation and tank before joining
- send chosen tank to server and enforce BR limits
- style lobby overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb9a020d883289d2b5783d2f1f78c