### PR TITLE
feat: perlin noise terrain generation

### DIFF
--- a/admin/terrain-editor.js
+++ b/admin/terrain-editor.js
@@ -1,7 +1,8 @@
 // terrain-editor.js
 // Summary: Terrain editor enabling direct 3D surface sculpting with a raised-cosine brush, camera presets,
-//          perspective control and shading.
-// Structure: state setup -> ground type management -> terrain initialization -> raised-cosine painting -> 3D plot with camera controls -> event wiring.
+//          perspective control, shading and Perlin-noise-based terrain generation.
+// Structure: state setup -> ground type management -> terrain initialization -> raised-cosine painting ->
+//            Perlin noise generation -> 3D plot with camera controls -> event wiring.
 // Usage: Imported by terrain.html; click or drag on the 3D plot to paint ground or elevation. Axes and camera settings are user configurable.
 
 // Default ground types with color, traction and viscosity for quick start
@@ -126,12 +127,84 @@ function handlePlotPaint(e) {
   update3DPlot();
 }
 
-// Fill elevation grid with random heights for quick terrain generation
-function randomizeTerrain() {
+// PerlinNoise generator based on public domain implementation by Stefan Gustavson
+// Used here for deterministic, natural-looking terrain generation.
+class PerlinNoise {
+  constructor() {
+    this.permutation = [
+      151,160,137,91,90,15,
+      131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,
+      8,99,37,240,21,10,23,190, 6,148,247,120,234,75,0,26,197,62,94,252,
+      219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,125,136,171,168,
+      68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,211,
+      133,230,220,105,92,41,55,46,245,40,244,102,143,54,65,25,63,161,1,216,
+      80,73,209,76,132,187,208,89,18,169,200,196,135,130,116,188,159,86,164,100,
+      109,198,173,186,3,64,52,217,226,250,124,123,5,202,38,147,118,126,255,82,
+      85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,119,248,
+      152,2,44,154,163,70,221,153,101,155,167,43,172,9,129,22,39,253,19,98,
+      108,110,79,113,224,232,178,185,112,104,218,246,97,228,251,34,242,193,238,210,
+      144,12,191,179,162,241,81,51,145,235,249,14,239,107,49,192,214,31,181,199,
+      106,157,184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,222,114,
+      67,29,24,72,243,141,128,195,78,66,215,61,156,180
+    ];
+    this.p = new Uint8Array(512);
+    for (let i = 0; i < 512; i++) {
+      this.p[i] = this.permutation[i & 255];
+    }
+  }
+  fade(t) { return t * t * t * (t * (t * 6 - 15) + 10); }
+  lerp(t, a, b) { return a + t * (b - a); }
+  grad(hash, x, y, z) {
+    const h = hash & 15;
+    const u = h < 8 ? x : y;
+    const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+    return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+  }
+  noise(x, y, z = 0) {
+    const X = Math.floor(x) & 255;
+    const Y = Math.floor(y) & 255;
+    const Z = Math.floor(z) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    z -= Math.floor(z);
+    const u = this.fade(x);
+    const v = this.fade(y);
+    const w = this.fade(z);
+    const A = this.p[X] + Y;
+    const AA = this.p[A] + Z;
+    const AB = this.p[A + 1] + Z;
+    const B = this.p[X + 1] + Y;
+    const BA = this.p[B] + Z;
+    const BB = this.p[B + 1] + Z;
+    return this.lerp(w,
+      this.lerp(v,
+        this.lerp(u, this.grad(this.p[AA], x, y, z),
+                     this.grad(this.p[BA], x - 1, y, z)),
+        this.lerp(u, this.grad(this.p[AB], x, y - 1, z),
+                     this.grad(this.p[BB], x - 1, y - 1, z))
+      ),
+      this.lerp(v,
+        this.lerp(u, this.grad(this.p[AA + 1], x, y, z - 1),
+                     this.grad(this.p[BA + 1], x - 1, y, z - 1)),
+        this.lerp(u, this.grad(this.p[AB + 1], x, y - 1, z - 1),
+                     this.grad(this.p[BB + 1], x - 1, y - 1, z - 1))
+      )
+    );
+  }
+}
+
+// Generate elevation grid using Perlin noise for more natural terrain
+function generatePerlinTerrain() {
   if (gridWidth === 0 || gridHeight === 0) return;
-  elevationGrid = Array.from({ length: gridHeight }, () =>
-    Array.from({ length: gridWidth }, () => Math.random() * maxHeight)
+  const noise = new PerlinNoise();
+  const scale = 10; // larger values flatten the terrain
+  elevationGrid = Array.from({ length: gridHeight }, (_, y) =>
+    Array.from({ length: gridWidth }, (_, x) => {
+      const value = noise.noise(x / scale, y / scale, 0);
+      return ((value + 1) / 2) * maxHeight; // normalize to [0, maxHeight]
+    })
   );
+  console.debug('Perlin terrain generated', { gridWidth, gridHeight });
   update3DPlot();
 }
 
@@ -206,7 +279,7 @@ function applyCameraLock() {
 // Event wiring
 renderGroundTypes();
 document.getElementById('addGroundBtn').addEventListener('click', addGroundType);
-document.getElementById('randomizeBtn').addEventListener('click', randomizeTerrain);
+document.getElementById('perlinBtn').addEventListener('click', generatePerlinTerrain);
 document.getElementById('showAxes').addEventListener('change', update3DPlot);
 document.getElementById('viewSelect').addEventListener('change', update3DPlot);
 document.getElementById('projectionType').addEventListener('change', update3DPlot);

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,6 +1,7 @@
 <!-- terrain.html
      Summary: Admin page for managing terrain presets with a direct 3D terrain editor that allows
-              clicking on the surface to sculpt ground types and elevation. The 3D view renders
+              clicking on the surface to sculpt ground types and elevation. Includes a Perlin-noise
+              generator for quickly creating natural-looking landscapes. The 3D view renders
               automatically whenever a map is created or its size/type is changed.
      Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
                and an expandable 3D editor featuring camera controls and shading.
@@ -88,7 +89,7 @@
           <input type="range" id="brushSizeY" min="1" max="10" value="2">
           <label for="brushSizeZ">Brush Height</label>
           <input type="range" id="brushSizeZ" min="1" max="20" value="5">
-          <button id="randomizeBtn">Randomize Terrain</button>
+          <button id="perlinBtn">Generate Perlin Terrain</button>
 
           <label for="showAxes">Show Axes</label>
           <input type="checkbox" id="showAxes" checked>


### PR DESCRIPTION
## Summary
- use Perlin noise to generate natural looking terrain
- rename editor button for Perlin noise creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acbc2700208328a62f7917945d5c9f