### PR TITLE
feat: add player authentication and stat tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A minimal browser-based multiplayer tank demo built with Node.js, Express, Socke
 - Hold `C` for freelook, `V` to toggle first/third person
 - Mouse wheel zoom
 - Modern admin dashboard with CRUD for nations, tanks, ammo and terrain plus live statistics
+- Secure player accounts with signup/login and persistent tracking of games, kills and deaths
 
 ## Requirements
 - Node.js 18+ and npm
@@ -18,7 +19,7 @@ Run these commands from a terminal (PowerShell on Windows):
 ```bash
 cd tanksfornothing
 npm install
-npm run setup   # create data/tanks.json and nations.json
+npm run setup   # create data files
 npm start
 ```
 
@@ -26,7 +27,7 @@ npm start
 ```powershell
 cd tanksfornothing
 npm install
-npm run setup   # create data/tanks.json and nations.json
+npm run setup   # create data files
 npm start
 ```
 
@@ -37,15 +38,13 @@ PORT=8080 npm start
 Set `NODE_ENV=production` when deploying to enable secure cookies.
 
 Set `ADMIN_PASSWORD` to change the admin login password (default `adminpass`).
+Set `JWT_SECRET` to a long random string to sign authentication tokens.
 
 ## Usage
-- Open `http://localhost:3000` in a modern browser.
-- Click the screen to capture the mouse and drive the tank.
-- Visit `http://localhost:3000/admin/admin.html` for the admin dashboard. A sidebar links to dedicated pages for Nations, Tanks,
-  Ammo, Terrain and Game Settings. Manage nations, then create tanks and ammo tied to those nations. The tank form provides class
-  dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine
-  horsepower sliders, separate sliders for maximum forward and reverse speeds, and controls for incline and rotation times. The ammo form captures name, nation, caliber, armor
-  penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
+ - Create an account at `http://localhost:3000/signup.html` then log in via `http://localhost:3000/login.html`.
+ - Open `http://localhost:3000` in a modern browser after logging in to join the battle.
+ - Click the screen to capture the mouse and drive the tank.
+ - Visit `http://localhost:3000/admin/admin.html` for the admin dashboard. A sidebar links to dedicated pages for Nations, Tanks, Ammo, Terrain and Game Settings. Manage nations, then create tanks and ammo tied to those nations. The tank form provides class dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine horsepower sliders, separate sliders for maximum forward and reverse speeds, and controls for incline and rotation times. The ammo form captures name, nation, caliber, armor penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
 
 ## Debugging
 The server logs player connections and updates to the console. Use `npm run dev` to auto-restart on changes.

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,8 @@
+{
+  "_comment": [
+    "Summary: Persisted user accounts for Tanks for Nothing.",
+    "Structure: JSON object with _comment array and users list of {username,passwordHash,stats}.",
+    "Usage: Managed automatically by server; do not edit manually."
+  ],
+  "users": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "cookie": "^0.6.0",
         "cookie-parser": "^1.4.7",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "socket.io": "^4.8.1",
         "three": "^0.179.1"
       }
@@ -61,6 +64,12 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -80,6 +89,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -141,9 +156,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -160,6 +175,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-parser/node_modules/cookie-signature": {
@@ -230,6 +254,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -283,6 +316,15 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -419,6 +461,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/finalhandler": {
@@ -594,6 +645,91 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -815,6 +951,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "dependencies": {
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",
+    "bcryptjs": "^2.4.3",
+    "cookie": "^0.6.0",
+    "jsonwebtoken": "^9.0.2",
     "socket.io": "^4.8.1",
     "three": "^0.179.1"
   }

--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,62 @@
+// auth.js
+// Summary: Handles signup and login form submissions plus navbar profile menu for Tanks for Nothing.
+// Structure: detect which form is present -> attach submit handlers -> toggle profile menu -> optional sign-out.
+// Usage: Included by login.html and signup.html pages.
+// ---------------------------------------------------------------------------
+
+function initMenu() {
+  const menu = document.querySelector('.profile-menu');
+  const pic = document.getElementById('profilePic');
+  if (pic) pic.addEventListener('click', () => menu.classList.toggle('show'));
+  const signOut = document.getElementById('signOut');
+  if (signOut)
+    signOut.addEventListener('click', async (e) => {
+      e.preventDefault();
+      await fetch('/api/logout', { method: 'POST' });
+    });
+}
+
+async function handleSignup(e) {
+  e.preventDefault();
+  const username = document.getElementById('signupUser').value;
+  const password = document.getElementById('signupPass').value;
+  const res = await fetch('/api/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  const msg = document.getElementById('authError');
+  if (res.ok) {
+    msg.style.color = '#80ff80';
+    msg.textContent = 'Signup successful. Please log in.';
+  } else {
+    const data = await res.json().catch(() => ({}));
+    msg.textContent = data.error || 'Signup failed';
+  }
+}
+
+async function handleLogin(e) {
+  e.preventDefault();
+  const username = document.getElementById('loginUser').value;
+  const password = document.getElementById('loginPass').value;
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  const msg = document.getElementById('authError');
+  if (res.ok) {
+    window.location.href = '/index.html';
+  } else {
+    const data = await res.json().catch(() => ({}));
+    msg.textContent = data.error || 'Login failed';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initMenu();
+  const signupForm = document.getElementById('signupForm');
+  if (signupForm) signupForm.addEventListener('submit', handleSignup);
+  const loginForm = document.getElementById('loginForm');
+  if (loginForm) loginForm.addEventListener('submit', handleLogin);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,20 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <nav id="navbar"><span>Tanks for Nothing</span></nav>
+  <nav id="navbar">
+    <span>Tanks for Nothing</span>
+    <div class="profile-menu">
+      <img id="profilePic" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAADUlEQVR42mP8/5+hHgAHggJ/lvE9GAAAAABJRU5ErkJggg==" alt="profile" />
+      <div class="profile-menu-content" id="profileMenuContent">
+        <a href="#">Manage Profiles</a>
+        <a href="#">Learning Zone</a>
+        <a href="#">My Details</a>
+        <a href="#">Subscription Details</a>
+        <a href="#">Manage Users</a>
+        <a href="#" id="signOut">Sign out</a>
+      </div>
+    </div>
+  </nav>
   <div id="lobby">
     <p>Select your nation and tank to join the battle.</p>
     <label for="nationSelect">Nation:</label>
@@ -22,6 +35,7 @@
     <div id="lobbyError"></div>
   </div>
   <div id="instructions" style="display:none">WASD move | Space brake | Mouse look | C freelook | V camera | Scroll zoom | 1-4 ammo</div>
+  <script type="module" src="nav.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script
     type="module"

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,39 @@
+<!-- login.html
+     Summary: Player login page for Tanks for Nothing.
+     Structure: navbar with profile menu then login form and helpful prompts.
+     Usage: Open to authenticate and start playing. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login - Tanks for Nothing</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav id="navbar">
+    <span>Tanks for Nothing</span>
+    <div class="profile-menu">
+      <img id="profilePic" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAADUlEQVR42mP8/5+hHgAHggJ/lvE9GAAAAABJRU5ErkJggg==" alt="profile" />
+      <div class="profile-menu-content" id="profileMenuContent">
+        <a href="#">Manage Profiles</a>
+        <a href="#">Learning Zone</a>
+        <a href="#">My Details</a>
+        <a href="#">Subscription Details</a>
+        <a href="#">Manage Users</a>
+        <a href="#" id="signOut">Sign out</a>
+      </div>
+    </div>
+  </nav>
+  <div id="authContainer">
+    <h2>Log in to play</h2>
+    <form id="loginForm">
+      <input type="text" id="loginUser" placeholder="Username" required />
+      <input type="password" id="loginPass" placeholder="Password" required />
+      <button type="submit">Log in</button>
+    </form>
+    <p>No account? <a href="/signup.html">Sign up here</a></p>
+    <div id="authError"></div>
+  </div>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/public/nav.js
+++ b/public/nav.js
@@ -1,0 +1,31 @@
+// nav.js
+// Summary: Handles navbar profile menu interactions and enforces authentication for Tanks for Nothing pages.
+// Structure: check auth -> update navbar -> attach menu toggle and sign-out handlers.
+// Usage: Imported by pages requiring login; redirects to login.html if not authenticated.
+// ---------------------------------------------------------------------------
+
+async function initNav() {
+  try {
+    const res = await fetch('/api/stats');
+    if (!res.ok) throw new Error('not auth');
+    const data = await res.json();
+    const title = document.querySelector('#navbar span');
+    title.textContent = `Tanks for Nothing - ${data.username}`;
+  } catch {
+    window.location.href = '/login.html';
+    return;
+  }
+
+  const menu = document.querySelector('.profile-menu');
+  const pic = document.getElementById('profilePic');
+  pic.addEventListener('click', () => menu.classList.toggle('show'));
+
+  const signOut = document.getElementById('signOut');
+  signOut.addEventListener('click', async (e) => {
+    e.preventDefault();
+    await fetch('/api/logout', { method: 'POST' });
+    window.location.href = '/login.html';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initNav);

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,39 @@
+<!-- signup.html
+     Summary: Player registration page for Tanks for Nothing.
+     Structure: navbar with profile menu then signup form and guidance.
+     Usage: Visit to create a new account. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Sign Up - Tanks for Nothing</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav id="navbar">
+    <span>Tanks for Nothing</span>
+    <div class="profile-menu">
+      <img id="profilePic" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAADUlEQVR42mP8/5+hHgAHggJ/lvE9GAAAAABJRU5ErkJggg==" alt="profile" />
+      <div class="profile-menu-content" id="profileMenuContent">
+        <a href="#">Manage Profiles</a>
+        <a href="#">Learning Zone</a>
+        <a href="#">My Details</a>
+        <a href="#">Subscription Details</a>
+        <a href="#">Manage Users</a>
+        <a href="#" id="signOut">Sign out</a>
+      </div>
+    </div>
+  </nav>
+  <div id="authContainer">
+    <h2>Create your account</h2>
+    <form id="signupForm">
+      <input type="text" id="signupUser" placeholder="Username" required />
+      <input type="password" id="signupPass" placeholder="Password" required />
+      <button type="submit">Sign up</button>
+    </form>
+    <p>Already have an account? <a href="/login.html">Log in</a></p>
+    <div id="authError"></div>
+  </div>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -78,3 +78,21 @@ canvas { display: block; }
 .profile-menu-content a { color: black; padding: 12px 16px; text-decoration: none; display: block; }
 .profile-menu-content a:hover { background-color: #f1f1f1; }
 .profile-menu.show .profile-menu-content { display: block; }
+
+/* Authentication form container */
+#authContainer {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(34,34,34,0.9);
+  padding: 20px;
+  border-radius: 6px;
+  text-align: center;
+  z-index: 1000;
+}
+#authContainer input {
+  margin: 5px;
+  padding: 5px;
+}
+#authError { color: #ff8080; margin-top: 5px; }

--- a/scripts/init-data.js
+++ b/scripts/init-data.js
@@ -10,6 +10,7 @@ const tanksFile = new URL('tanks.json', dataDir);
 const nationsFile = new URL('nations.json', dataDir);
 const ammoFile = new URL('ammo.json', dataDir);
 const terrainFile = new URL('terrains.json', dataDir);
+const usersFile = new URL('users.json', dataDir);
 
 async function init() {
   await fs.mkdir(dataDir, { recursive: true });
@@ -111,6 +112,23 @@ async function init() {
     };
     await fs.writeFile(terrainFile, JSON.stringify(terrainData, null, 2));
     console.log('Created data/terrains.json');
+  }
+
+  // Ensure users.json exists
+  try {
+    await fs.access(usersFile);
+    console.log('users.json already exists');
+  } catch {
+    const usersData = {
+      _comment: [
+        'Summary: Persisted user accounts for Tanks for Nothing.',
+        'Structure: JSON object with _comment array and users list of {username,passwordHash,stats}.',
+        'Usage: Managed automatically by server; do not edit manually.'
+      ],
+      users: []
+    };
+    await fs.writeFile(usersFile, JSON.stringify(usersData, null, 2));
+    console.log('Created data/users.json');
   }
 }
 


### PR DESCRIPTION
## Summary
- add bcrypt/JWT authentication with signup, login, logout and stats endpoints
- track games, kills and deaths for each user and require auth to join
- create login/signup pages with profile menu and setup script for users.json

## Testing
- `node --check tanksfornothing-server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc1200060832884f7e5c75579a47b