### PR TITLE
Add capture-the-flag placement to map editor

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -280,7 +280,8 @@ function collectTerrainForm() {
     size: {
       x: parseFloat(document.getElementById('sizeX').value),
       y: parseFloat(document.getElementById('sizeY').value)
-    }
+    },
+    flags: window.getTerrainFlags ? window.getTerrainFlags() : null
   };
 }
 
@@ -305,6 +306,7 @@ function openTerrainEditor(i) {
   if (i === undefined) {
     editingTerrainIndex = null;
     clearTerrainForm();
+    window.existingFlags = null;
     document.getElementById('saveTerrainBtn').innerText = 'Add Terrain';
   } else {
     editingTerrainIndex = Number(i);
@@ -313,6 +315,7 @@ function openTerrainEditor(i) {
     document.getElementById('terrainType').value = t.type;
     document.getElementById('sizeX').value = t.size.x;
     document.getElementById('sizeY').value = t.size.y;
+    window.existingFlags = t.flags || null;
     document.getElementById('saveTerrainBtn').innerText = 'Update Terrain';
   }
   document.dispatchEvent(new Event('terrain-editor-opened'));
@@ -328,6 +331,7 @@ function clearTerrainForm() {
   document.getElementById('terrainType').value = 'snow';
   document.getElementById('sizeX').value = '1';
   document.getElementById('sizeY').value = '1';
+  window.existingFlags = null;
 }
 
 function setCurrentTerrain(i) {

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -82,7 +82,20 @@
           <select id="mode">
             <option value="ground">Ground</option>
             <option value="elevation">Elevation</option>
+            <option value="flags">Flags</option>
           </select>
+          <label for="flagSelect" class="flag-controls" style="display:none">Flag</label>
+          <select id="flagSelect" class="flag-controls" style="display:none">
+            <option value="red-a">Red A</option>
+            <option value="red-b">Red B</option>
+            <option value="red-c">Red C</option>
+            <option value="red-d">Red D</option>
+            <option value="blue-a">Blue A</option>
+            <option value="blue-b">Blue B</option>
+            <option value="blue-c">Blue C</option>
+            <option value="blue-d">Blue D</option>
+          </select>
+          <p id="flagInstructions" class="flag-controls instructions" style="display:none">Select a flag then click the map to place it.</p>
           <label for="brushSizeX">Brush Size X (cells)</label>
           <input type="range" id="brushSizeX" min="1" max="10" value="2">
           <label for="brushSizeY">Brush Size Y (cells)</label>

--- a/data/terrains.json
+++ b/data/terrains.json
@@ -1,7 +1,7 @@
 {
   "_comment": [
     "Summary: Persisted terrain details and selected index for Tanks for Nothing.",
-    "Structure: JSON object with _comment array, current index and terrains list of {name,type,size}.",
+    "Structure: JSON object with _comment array, current index and terrains list of {name,type,size,flags}.",
     "Usage: Managed automatically by server; do not edit manually."
   ],
   "current": 0,
@@ -9,7 +9,11 @@
     {
       "name": "flat",
       "type": "default",
-      "size": { "x": 1, "y": 1 }
+      "size": { "x": 1, "y": 1 },
+      "flags": {
+        "red": { "a": null, "b": null, "c": null, "d": null },
+        "blue": { "a": null, "b": null, "c": null, "d": null }
+      }
     }
   ]
 }

--- a/scripts/init-data.js
+++ b/scripts/init-data.js
@@ -102,12 +102,20 @@ async function init() {
     const terrainData = {
       _comment: [
         'Summary: Persisted terrain details and selected index for Tanks for Nothing.',
-        'Structure: JSON object with _comment array, current index and terrains list of {name,type,size}.',
+        'Structure: JSON object with _comment array, current index and terrains list of {name,type,size,flags}.',
         'Usage: Managed automatically by server; do not edit manually.'
       ],
       current: 0,
       terrains: [
-        { name: 'flat', type: 'default', size: { x: 1, y: 1 } }
+        {
+          name: 'flat',
+          type: 'default',
+          size: { x: 1, y: 1 },
+          flags: {
+            red: { a: null, b: null, c: null, d: null },
+            blue: { a: null, b: null, c: null, d: null }
+          }
+        }
       ]
     };
     await fs.writeFile(terrainFile, JSON.stringify(terrainData, null, 2));


### PR DESCRIPTION
## Summary
- allow map editor to place red and blue flag points (A-D)
- persist capture-the-flag positions in terrain data and API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc3f012f48328971daf8a80e4ccd4