### PR TITLE
Fix signup and add admin user stats page

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -39,6 +39,7 @@
       <a href="tanks.html">Tanks</a>
       <a href="ammo.html">Ammo</a>
       <a href="terrain.html">Terrain</a>
+      <a href="users.html">Users</a>
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -42,6 +42,7 @@ let nationsCache = [];
 let tanksCache = [];
 let ammoCache = [];
 let terrainsCache = [];
+let usersCache = [];
 let editingNationIndex = null;
 let editingTankIndex = null;
 let editingAmmoIndex = null;
@@ -53,6 +54,7 @@ async function loadData() {
   nationsCache = await fetch('/api/nations').then(r => r.json());
   tanksCache = await fetch('/api/tanks').then(r => r.json());
   ammoCache = await fetch('/api/ammo').then(r => r.json());
+  usersCache = await fetch('/api/users').then(r => r.json());
   const terrainData = await fetch('/api/terrains').then(r => r.json());
   terrainsCache = terrainData.terrains;
   currentTerrainIndex = terrainData.current ?? 0;
@@ -90,6 +92,14 @@ async function loadData() {
     ).join('');
     ammoDiv.querySelectorAll('.edit-ammo').forEach(btn => btn.addEventListener('click', () => editAmmo(btn.dataset.i)));
     ammoDiv.querySelectorAll('.del-ammo').forEach(btn => btn.addEventListener('click', () => deleteAmmo(btn.dataset.i)));
+  }
+
+  // Populate user stats table when on Users page
+  const userTable = document.getElementById('userTableBody');
+  if (userTable) {
+    userTable.innerHTML = usersCache.map(u =>
+      `<tr><td>${u.username}</td><td>${u.stats.games}</td><td>${u.stats.kills}</td><td>${u.stats.deaths}</td></tr>`
+    ).join('');
   }
 
   renderTerrainTable();

--- a/admin/ammo.html
+++ b/admin/ammo.html
@@ -39,6 +39,7 @@
       <a href="tanks.html">Tanks</a>
       <a href="ammo.html">Ammo</a>
       <a href="terrain.html">Terrain</a>
+      <a href="users.html">Users</a>
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -39,6 +39,7 @@
       <a href="tanks.html">Tanks</a>
       <a href="ammo.html">Ammo</a>
       <a href="terrain.html">Terrain</a>
+      <a href="users.html">Users</a>
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">

--- a/admin/tanks.html
+++ b/admin/tanks.html
@@ -39,6 +39,7 @@
       <a href="tanks.html">Tanks</a>
       <a href="ammo.html">Ammo</a>
       <a href="terrain.html">Terrain</a>
+      <a href="users.html">Users</a>
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -43,6 +43,7 @@
       <a href="tanks.html">Tanks</a>
       <a href="ammo.html">Ammo</a>
       <a href="terrain.html">Terrain</a>
+      <a href="users.html">Users</a>
       <a href="settings.html">Game Settings</a>
     </aside>
     <main id="mainContent">

--- a/admin/users.html
+++ b/admin/users.html
@@ -1,12 +1,12 @@
-<!-- settings.html
-     Summary: Placeholder admin page for future game settings.
-     Structure: login, navbar with profile menu, sidebar navigation and settings card.
-     Usage: Visit /admin/settings.html after logging in. -->
+<!-- users.html
+     Summary: Admin page listing registered users and their statistics.
+     Structure: login, navbar with profile menu, sidebar navigation and user stats table.
+     Usage: Visit /admin/users.html after logging in to review player metrics. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Game Settings</title>
+  <title>User Stats</title>
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="admin.css">
 </head>
@@ -44,8 +44,14 @@
     </aside>
     <main id="mainContent">
       <section class="card">
-        <h2>Game Settings</h2>
-        <p>Additional configuration options will appear here.</p>
+        <h2>Users</h2>
+        <p class="instructions">Registered users and their stats.</p>
+        <table>
+          <thead>
+            <tr><th>Username</th><th>Games</th><th>Kills</th><th>Deaths</th></tr>
+          </thead>
+          <tbody id="userTableBody"></tbody>
+        </table>
       </section>
     </main>
   </div>

--- a/public/auth.js
+++ b/public/auth.js
@@ -20,6 +20,11 @@ async function handleSignup(e) {
   e.preventDefault();
   const username = document.getElementById('signupUser').value;
   const password = document.getElementById('signupPass').value;
+  if (password.length < 6) {
+    const msg = document.getElementById('authError');
+    msg.textContent = 'Password must be at least 6 characters';
+    return;
+  }
   const res = await fetch('/api/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/public/signup.html
+++ b/public/signup.html
@@ -28,9 +28,10 @@
     <h2>Create your account</h2>
     <form id="signupForm">
       <input type="text" id="signupUser" placeholder="Username" required />
-      <input type="password" id="signupPass" placeholder="Password" required />
+      <input type="password" id="signupPass" placeholder="Password" minlength="6" required />
       <button type="submit">Sign up</button>
     </form>
+    <p class="instructions">Password must be at least 6 characters.</p>
     <p>Already have an account? <a href="/login.html">Log in</a></p>
     <div id="authError"></div>
   </div>

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -254,6 +254,7 @@ await loadUsers();
 app.use(express.static('public'));
 app.use('/admin', express.static('admin'));
 app.use(express.json());
+app.use(express.urlencoded({ extended: false })); // support classic form posts
 app.use(cookieParser());
 
 // Admin authentication middleware
@@ -291,6 +292,12 @@ app.post('/admin/logout', (req, res) => {
 app.get('/admin/status', (req, res) => {
   if (req.cookies && req.cookies.admin === 'true') return res.json({ admin: true });
   res.status(401).json({ admin: false });
+});
+
+// Return all user statistics for admin dashboard
+app.get('/api/users', requireAdmin, (req, res) => {
+  const list = Array.from(users, ([username, u]) => ({ username, stats: u.stats }));
+  res.json(list);
 });
 
 // User signup endpoint with bcrypt password hashing


### PR DESCRIPTION
## Summary
- Accept urlencoded form posts during signup to prevent erroneous 'invalid credentials' errors
- Add client-side password length check and guidance on the signup page
- Introduce Users page in admin dashboard with sidebar link and user stats table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd1201da4832890be904125f62d40