### PR TITLE
feat: add perlin noise controls

### DIFF
--- a/admin/terrain-editor.js
+++ b/admin/terrain-editor.js
@@ -1,10 +1,11 @@
 // terrain-editor.js
 // Summary: Terrain editor enabling direct 3D surface sculpting with a raised-cosine brush, camera presets,
-//          perspective control, shading, Perlin-noise-based terrain generation and capture-the-flag
-//          position placement.
+//          perspective control, shading, Perlin-noise-based terrain generation (with adjustable scale
+//          and amplitude controls) and capture-the-flag position placement.
 // Structure: state setup -> ground type management -> terrain initialization -> raised-cosine painting ->
 //            Perlin noise generation -> 3D plot with camera controls -> event wiring.
-// Usage: Imported by terrain.html; click or drag on the 3D plot to paint ground or elevation. Axes and camera settings are user configurable.
+// Usage: Imported by terrain.html; click or drag on the 3D plot to paint ground or elevation. Axes and
+//        camera settings are user configurable.
 
 // Default ground types with color, traction and viscosity for quick start
 const defaultGroundTypes = [
@@ -218,14 +219,17 @@ class PerlinNoise {
 function generatePerlinTerrain() {
   if (gridWidth === 0 || gridHeight === 0) return;
   const noise = new PerlinNoise();
-  const scale = 10; // larger values flatten the terrain
+  const scaleInput = Number(document.getElementById('perlinScale').value);
+  const amplitudeInput = Number(document.getElementById('perlinAmplitude').value);
+  const scale = Math.max(1, scaleInput || 10);
+  const amplitude = Math.max(1, Math.min(maxHeight, amplitudeInput || maxHeight));
   elevationGrid = Array.from({ length: gridHeight }, (_, y) =>
     Array.from({ length: gridWidth }, (_, x) => {
       const value = noise.noise(x / scale, y / scale, 0);
-      return ((value + 1) / 2) * maxHeight; // normalize to [0, maxHeight]
+      return ((value + 1) / 2) * amplitude; // normalize to [0, amplitude]
     })
   );
-  console.debug('Perlin terrain generated', { gridWidth, gridHeight });
+  console.debug('Perlin terrain generated', { gridWidth, gridHeight, scale, amplitude });
   update3DPlot();
 }
 

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,8 +1,8 @@
 <!-- terrain.html
      Summary: Admin page for managing terrain presets with a direct 3D terrain editor that allows
               clicking on the surface to sculpt ground types and elevation. Includes a Perlin-noise
-              generator for quickly creating natural-looking landscapes. The 3D view renders
-              automatically whenever a map is created or its size/type is changed.
+              generator with adjustable controls for quickly creating natural-looking landscapes. The
+              3D view renders automatically whenever a map is created or its size/type is changed.
      Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
                and an expandable 3D editor featuring camera controls and shading.
      Usage: Visit /admin/terrain.html after logging in to manage terrains and design custom maps. -->
@@ -103,6 +103,13 @@
           <input type="range" id="brushSizeY" min="1" max="10" value="2">
           <label for="brushSizeZ">Brush Height</label>
           <input type="range" id="brushSizeZ" min="1" max="20" value="5">
+
+          <label for="perlinScale">Perlin Scale</label>
+          <input type="number" id="perlinScale" min="1" max="100" value="10">
+
+          <label for="perlinAmplitude">Perlin Amplitude</label>
+          <input type="number" id="perlinAmplitude" min="1" max="100" value="100">
+
           <button id="perlinBtn">Generate Perlin Terrain</button>
 
           <label for="showAxes">Show Axes</label>


### PR DESCRIPTION
## Summary
- add adjustable scale and amplitude inputs for Perlin noise terrain generation
- expose Perlin controls in terrain editor and wire them into generation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd7d6478c8328b3adabdfc14fbc64