### PR TITLE
feat: add tank geometry and turret limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ Set `JWT_SECRET` to a long random string to sign authentication tokens.
  - Create an account at `http://localhost:3000/signup.html` then log in via `http://localhost:3000/login.html`.
  - Open `http://localhost:3000` in a modern browser after logging in to join the battle.
  - Click the screen to capture the mouse and drive the tank.
- - Visit `http://localhost:3000/admin/admin.html` for the admin dashboard. A sidebar links to dedicated pages for Nations, Tanks, Ammo, Terrain and Game Settings. Manage nations, then create tanks and ammo tied to those nations. The tank form provides class dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine horsepower sliders, separate sliders for maximum forward and reverse speeds, and controls for incline and rotation times. The ammo form captures name, nation, caliber, armor penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
+- Visit `http://localhost:3000/admin/admin.html` for the admin dashboard. A sidebar links to dedicated pages for Nations, Tanks, Ammo, Terrain and Game Settings. Manage nations, then create tanks and ammo tied to those nations. The tank form provides class dropdowns, a BR slider, armour and cannon caliber sliders, checkboxes for HE/HEAT/AP/Smoke ammo types, crew and engine horsepower sliders, separate sliders for maximum forward and reverse speeds, and controls for incline and rotation times. The ammo form captures name, nation, caliber, armor penetration, type, explosion radius and penetration at 0m/100m. Data persists across restarts.
+
+### Tank geometry and turret limits
+The tank editor now includes additional sliders for turret elevation limits and chassis/turret dimensions. Configure:
+
+- Max Turret Incline / Decline (0–50° / 0–25°)
+- Body Width, Length and Height (1–5m / 1–10m / 1–3m)
+- Turret Width, Length and Height (1–3m / 1–5m / 0.25–2m)
 
 ## Debugging
 The server logs player connections and updates to the console. Use `npm run dev` to auto-restart on changes.

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -164,7 +164,15 @@ function collectTankForm() {
     maxReverseSpeed: parseFloat(document.getElementById('tankMaxReverse').value),
     incline: parseInt(document.getElementById('tankIncline').value, 10),
     bodyRotation: parseInt(document.getElementById('tankBodyRot').value, 10),
-    turretRotation: parseInt(document.getElementById('tankTurretRot').value, 10)
+    turretRotation: parseInt(document.getElementById('tankTurretRot').value, 10),
+    maxTurretIncline: parseInt(document.getElementById('tankMaxTurretIncline').value, 10),
+    maxTurretDecline: parseInt(document.getElementById('tankMaxTurretDecline').value, 10),
+    bodyWidth: parseFloat(document.getElementById('tankBodyWidth').value),
+    bodyLength: parseFloat(document.getElementById('tankBodyLength').value),
+    bodyHeight: parseFloat(document.getElementById('tankBodyHeight').value),
+    turretWidth: parseFloat(document.getElementById('tankTurretWidth').value),
+    turretLength: parseFloat(document.getElementById('tankTurretLength').value),
+    turretHeight: parseFloat(document.getElementById('tankTurretHeight').value)
   };
 }
 
@@ -199,6 +207,14 @@ function editTank(i) {
   document.getElementById('tankIncline').value = t.incline; document.getElementById('inclineVal').innerText = t.incline;
   document.getElementById('tankBodyRot').value = t.bodyRotation; document.getElementById('bodyRotVal').innerText = t.bodyRotation;
   document.getElementById('tankTurretRot').value = t.turretRotation; document.getElementById('turretRotVal').innerText = t.turretRotation;
+  document.getElementById('tankMaxTurretIncline').value = t.maxTurretIncline ?? 0; document.getElementById('maxTurretInclineVal').innerText = t.maxTurretIncline ?? 0;
+  document.getElementById('tankMaxTurretDecline').value = t.maxTurretDecline ?? 0; document.getElementById('maxTurretDeclineVal').innerText = t.maxTurretDecline ?? 0;
+  document.getElementById('tankBodyWidth').value = t.bodyWidth ?? 1; document.getElementById('bodyWidthVal').innerText = t.bodyWidth ?? 1;
+  document.getElementById('tankBodyLength').value = t.bodyLength ?? 1; document.getElementById('bodyLengthVal').innerText = t.bodyLength ?? 1;
+  document.getElementById('tankBodyHeight').value = t.bodyHeight ?? 1; document.getElementById('bodyHeightVal').innerText = t.bodyHeight ?? 1;
+  document.getElementById('tankTurretWidth').value = t.turretWidth ?? 1; document.getElementById('turretWidthVal').innerText = t.turretWidth ?? 1;
+  document.getElementById('tankTurretLength').value = t.turretLength ?? 1; document.getElementById('turretLengthVal').innerText = t.turretLength ?? 1;
+  document.getElementById('tankTurretHeight').value = t.turretHeight ?? 0.25; document.getElementById('turretHeightVal').innerText = t.turretHeight ?? 0.25;
   editingTankIndex = i;
   document.getElementById('addTankBtn').innerText = 'Update Tank';
 }
@@ -223,6 +239,14 @@ function clearTankForm() {
   document.getElementById('tankIncline').value = 2; document.getElementById('inclineVal').innerText = '';
   document.getElementById('tankBodyRot').value = 1; document.getElementById('bodyRotVal').innerText = '';
   document.getElementById('tankTurretRot').value = 1; document.getElementById('turretRotVal').innerText = '';
+  document.getElementById('tankMaxTurretIncline').value = 0; document.getElementById('maxTurretInclineVal').innerText = '';
+  document.getElementById('tankMaxTurretDecline').value = 0; document.getElementById('maxTurretDeclineVal').innerText = '';
+  document.getElementById('tankBodyWidth').value = 1; document.getElementById('bodyWidthVal').innerText = '';
+  document.getElementById('tankBodyLength').value = 1; document.getElementById('bodyLengthVal').innerText = '';
+  document.getElementById('tankBodyHeight').value = 1; document.getElementById('bodyHeightVal').innerText = '';
+  document.getElementById('tankTurretWidth').value = 1; document.getElementById('turretWidthVal').innerText = '';
+  document.getElementById('tankTurretLength').value = 1; document.getElementById('turretLengthVal').innerText = '';
+  document.getElementById('tankTurretHeight').value = 0.25; document.getElementById('turretHeightVal').innerText = '';
 }
 
 function collectAmmoForm() {

--- a/admin/tanks.html
+++ b/admin/tanks.html
@@ -100,6 +100,38 @@
           <input id="tankTurretRot" type="range" min="1" max="60" step="1" oninput="document.getElementById('turretRotVal').innerText=this.value">
           <span id="turretRotVal"></span>
         </label>
+        <label>Max Turret Incline (deg)
+          <input id="tankMaxTurretIncline" type="range" min="0" max="50" step="1" oninput="document.getElementById('maxTurretInclineVal').innerText=this.value">
+          <span id="maxTurretInclineVal"></span>
+        </label>
+        <label>Max Turret Decline (deg)
+          <input id="tankMaxTurretDecline" type="range" min="0" max="25" step="1" oninput="document.getElementById('maxTurretDeclineVal').innerText=this.value">
+          <span id="maxTurretDeclineVal"></span>
+        </label>
+        <label>Body Width (m)
+          <input id="tankBodyWidth" type="range" min="1" max="5" step="0.25" oninput="document.getElementById('bodyWidthVal').innerText=this.value">
+          <span id="bodyWidthVal"></span>
+        </label>
+        <label>Body Length (m)
+          <input id="tankBodyLength" type="range" min="1" max="10" step="0.25" oninput="document.getElementById('bodyLengthVal').innerText=this.value">
+          <span id="bodyLengthVal"></span>
+        </label>
+        <label>Body Height (m)
+          <input id="tankBodyHeight" type="range" min="1" max="3" step="0.25" oninput="document.getElementById('bodyHeightVal').innerText=this.value">
+          <span id="bodyHeightVal"></span>
+        </label>
+        <label>Turret Width (m)
+          <input id="tankTurretWidth" type="range" min="1" max="3" step="0.25" oninput="document.getElementById('turretWidthVal').innerText=this.value">
+          <span id="turretWidthVal"></span>
+        </label>
+        <label>Turret Length (m)
+          <input id="tankTurretLength" type="range" min="1" max="5" step="0.25" oninput="document.getElementById('turretLengthVal').innerText=this.value">
+          <span id="turretLengthVal"></span>
+        </label>
+        <label>Turret Height (m)
+          <input id="tankTurretHeight" type="range" min="0.25" max="2" step="0.25" oninput="document.getElementById('turretHeightVal').innerText=this.value">
+          <span id="turretHeightVal"></span>
+        </label>
         <button id="addTankBtn">Add Tank</button>
       </section>
     </main>

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -1,8 +1,8 @@
 // tanksfornothing-client.js
 // Summary: Browser client for Tanks for Nothing. Provides lobby tank selection,
-//          renders 3D scene, handles user input and firing mechanics, uses
-//          Cannon.js for simple collision physics and synchronizes state with a
-//          server via Socket.IO.
+//          renders a dimensioned 3D tank based on server-supplied parameters,
+//          handles user input and firing mechanics, uses Cannon.js for simple
+//          collision physics and synchronizes state with a server via Socket.IO.
 // Structure: lobby data fetch -> scene setup -> physics setup -> input handling ->
 //             firing helpers -> animation loop -> optional networking.
 // Usage: Included by index.html; requires Socket.IO for multiplayer networking and
@@ -164,6 +164,7 @@ joinBtn.addEventListener('click', () => {
   }
   lobby.style.display = 'none';
   instructions.style.display = 'block';
+  applyTankConfig(tank);
   if (socket) socket.emit('join', tank);
 });
 
@@ -188,12 +189,22 @@ const defaultTank = {
   horsepower: 500,
   maxSpeed: 40, // km/h
   maxReverseSpeed: 15, // km/h
-  bodyRotation: 20 // seconds for full rotation
+  bodyRotation: 20, // seconds for full rotation
+  maxTurretIncline: 50,
+  maxTurretDecline: 25,
+  bodyWidth: 2,
+  bodyLength: 4,
+  bodyHeight: 1,
+  turretWidth: 1.5,
+  turretLength: 1.5,
+  turretHeight: 0.5
 };
-// Movement coefficients derived from tank stats
-const MAX_SPEED = defaultTank.maxSpeed / 3.6; // convert km/h to m/s
-const MAX_REVERSE_SPEED = defaultTank.maxReverseSpeed / 3.6; // convert km/h to m/s
-const ROT_SPEED = (2 * Math.PI) / defaultTank.bodyRotation; // radians per second
+// Movement coefficients derived from tank stats; mutable to apply tank-specific values
+let MAX_SPEED = defaultTank.maxSpeed / 3.6; // convert km/h to m/s
+let MAX_REVERSE_SPEED = defaultTank.maxReverseSpeed / 3.6; // convert km/h to m/s
+let ROT_SPEED = (2 * Math.PI) / defaultTank.bodyRotation; // radians per second
+let MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretIncline);
+let MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretDecline);
 // Acceleration used when W/S are pressed. Tuned so max speed is reached in a few seconds.
 const ACCELERATION = MAX_SPEED / 3;
 let currentSpeed = 0;
@@ -313,7 +324,7 @@ function init() {
 
   // Tank body graphics
   const body = new THREE.Mesh(
-    new THREE.BoxGeometry(2, 1, 4),
+    new THREE.BoxGeometry(defaultTank.bodyWidth, defaultTank.bodyHeight, defaultTank.bodyLength),
     new THREE.MeshStandardMaterial({ color: 0x555555 })
   );
   scene.add(body);
@@ -321,10 +332,10 @@ function init() {
 
   // Turret and gun
   turret = new THREE.Mesh(
-    new THREE.BoxGeometry(1.5, 0.5, 1.5),
+    new THREE.BoxGeometry(defaultTank.turretWidth, defaultTank.turretHeight, defaultTank.turretLength),
     new THREE.MeshStandardMaterial({ color: 0x777777 })
   );
-  turret.position.y = 0.75;
+  turret.position.y = defaultTank.bodyHeight / 2 + defaultTank.turretHeight / 2;
   const gun = new THREE.Mesh(
     new THREE.CylinderGeometry(0.1, 0.1, 3),
     new THREE.MeshStandardMaterial({ color: 0x777777 })
@@ -335,10 +346,10 @@ function init() {
   tank.add(turret);
 
   // Chassis physics body mirrors tank mesh
-  const box = new CANNON.Box(new CANNON.Vec3(1, 0.5, 2));
+  const box = new CANNON.Box(new CANNON.Vec3(defaultTank.bodyWidth / 2, defaultTank.bodyHeight / 2, defaultTank.bodyLength / 2));
   chassisBody = new CANNON.Body({ mass: defaultTank.mass });
   chassisBody.addShape(box);
-  chassisBody.position.set(0, 1, 0);
+  chassisBody.position.set(0, defaultTank.bodyHeight / 2, 0);
   world.addBody(chassisBody);
 
   camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
@@ -394,13 +405,51 @@ function init() {
   animate();
 }
 
+function applyTankConfig(t) {
+  MAX_SPEED = (t.maxSpeed ?? defaultTank.maxSpeed) / 3.6;
+  MAX_REVERSE_SPEED = (t.maxReverseSpeed ?? defaultTank.maxReverseSpeed) / 3.6;
+  ROT_SPEED = (2 * Math.PI) / (t.bodyRotation ?? defaultTank.bodyRotation);
+  MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(t.maxTurretIncline ?? defaultTank.maxTurretIncline);
+  MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(t.maxTurretDecline ?? defaultTank.maxTurretDecline);
+
+  tank.geometry.dispose();
+  tank.geometry = new THREE.BoxGeometry(
+    t.bodyWidth ?? defaultTank.bodyWidth,
+    t.bodyHeight ?? defaultTank.bodyHeight,
+    t.bodyLength ?? defaultTank.bodyLength
+  );
+  turret.geometry.dispose();
+  turret.geometry = new THREE.BoxGeometry(
+    t.turretWidth ?? defaultTank.turretWidth,
+    t.turretHeight ?? defaultTank.turretHeight,
+    t.turretLength ?? defaultTank.turretLength
+  );
+  turret.position.y =
+    (t.bodyHeight ?? defaultTank.bodyHeight) / 2 +
+    (t.turretHeight ?? defaultTank.turretHeight) / 2;
+
+  world.removeBody(chassisBody);
+  const box = new CANNON.Box(
+    new CANNON.Vec3(
+      (t.bodyWidth ?? defaultTank.bodyWidth) / 2,
+      (t.bodyHeight ?? defaultTank.bodyHeight) / 2,
+      (t.bodyLength ?? defaultTank.bodyLength) / 2
+    )
+  );
+  chassisBody = new CANNON.Body({ mass: t.mass ?? defaultTank.mass });
+  chassisBody.addShape(box);
+  chassisBody.position.set(0, (t.bodyHeight ?? defaultTank.bodyHeight) / 2, 0);
+  world.addBody(chassisBody);
+  currentSpeed = 0;
+}
+
 function onMouseMove(e) {
   const sensitivity = 0.002;
   turret.rotation.y -= e.movementX * sensitivity;
   turret.rotation.x = THREE.MathUtils.clamp(
     turret.rotation.x - e.movementY * sensitivity,
-    -0.5,
-    0.5
+    -MAX_TURRET_DECLINE,
+    MAX_TURRET_INCLINE
   );
 }
 function animate() {

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -386,6 +386,14 @@ function validateTank(t) {
   if (typeof t.incline !== 'number' || t.incline < 2 || t.incline > 12) return 'incline out of range';
   if (typeof t.bodyRotation !== 'number' || t.bodyRotation < 1 || t.bodyRotation > 60) return 'invalid body rotation';
   if (typeof t.turretRotation !== 'number' || t.turretRotation < 1 || t.turretRotation > 60) return 'invalid turret rotation';
+  if (typeof t.maxTurretIncline !== 'number' || t.maxTurretIncline < 0 || t.maxTurretIncline > 50 || t.maxTurretIncline % 1 !== 0) return 'invalid turret incline';
+  if (typeof t.maxTurretDecline !== 'number' || t.maxTurretDecline < 0 || t.maxTurretDecline > 25 || t.maxTurretDecline % 1 !== 0) return 'invalid turret decline';
+  if (typeof t.bodyWidth !== 'number' || t.bodyWidth < 1 || t.bodyWidth > 5 || (t.bodyWidth * 4) % 1 !== 0) return 'invalid body width';
+  if (typeof t.bodyLength !== 'number' || t.bodyLength < 1 || t.bodyLength > 10 || (t.bodyLength * 4) % 1 !== 0) return 'invalid body length';
+  if (typeof t.bodyHeight !== 'number' || t.bodyHeight < 1 || t.bodyHeight > 3 || (t.bodyHeight * 4) % 1 !== 0) return 'invalid body height';
+  if (typeof t.turretWidth !== 'number' || t.turretWidth < 1 || t.turretWidth > 3 || (t.turretWidth * 4) % 1 !== 0) return 'invalid turret width';
+  if (typeof t.turretLength !== 'number' || t.turretLength < 1 || t.turretLength > 5 || (t.turretLength * 4) % 1 !== 0) return 'invalid turret length';
+  if (typeof t.turretHeight !== 'number' || t.turretHeight < 0.25 || t.turretHeight > 2 || (t.turretHeight * 4) % 1 !== 0) return 'invalid turret height';
   return {
     name: t.name.trim(),
     nation: t.nation,
@@ -400,7 +408,15 @@ function validateTank(t) {
     maxReverseSpeed: t.maxReverseSpeed,
     incline: t.incline,
     bodyRotation: t.bodyRotation,
-    turretRotation: t.turretRotation
+    turretRotation: t.turretRotation,
+    maxTurretIncline: t.maxTurretIncline,
+    maxTurretDecline: t.maxTurretDecline,
+    bodyWidth: t.bodyWidth,
+    bodyLength: t.bodyLength,
+    bodyHeight: t.bodyHeight,
+    turretWidth: t.turretWidth,
+    turretLength: t.turretLength,
+    turretHeight: t.turretHeight
   };
 }
 


### PR DESCRIPTION
## Summary
- add admin sliders for turret elevation and body/turret dimensions
- validate and persist new geometry fields on server
- render tanks with server-provided dimensions and clamp turret angles in client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd8f76b30832894771ab5b7910e3c