### PR TITLE
Add tank destroyer class and horizontal traverse

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -171,6 +171,7 @@ function collectTankForm() {
     incline: parseInt(document.getElementById('tankIncline').value, 10),
     bodyRotation: parseInt(document.getElementById('tankBodyRot').value, 10),
     turretRotation: parseInt(document.getElementById('tankTurretRot').value, 10),
+    horizontalTraverse: parseInt(document.getElementById('tankHorizontalTraverse').value, 10),
     maxTurretIncline: parseInt(document.getElementById('tankMaxTurretIncline').value, 10),
     maxTurretDecline: parseInt(document.getElementById('tankMaxTurretDecline').value, 10),
     bodyWidth: parseFloat(document.getElementById('tankBodyWidth').value),
@@ -221,6 +222,7 @@ function renderTankTable() {
       <td>${t.crew}</td>
       <td>${t.engineHp}</td>
       <td>${t.maxSpeed}</td>
+      <td>${t.horizontalTraverse ?? 0}</td>
       <td>${t.bodyWidth}</td>
       <td>${t.bodyLength}</td>
       <td>${t.bodyHeight}</td>
@@ -247,6 +249,7 @@ function editTank(i) {
   document.getElementById('tankIncline').value = t.incline; document.getElementById('inclineVal').innerText = t.incline;
   document.getElementById('tankBodyRot').value = t.bodyRotation; document.getElementById('bodyRotVal').innerText = t.bodyRotation;
   document.getElementById('tankTurretRot').value = t.turretRotation; document.getElementById('turretRotVal').innerText = t.turretRotation;
+  document.getElementById('tankHorizontalTraverse').value = t.horizontalTraverse ?? 0; document.getElementById('horizontalTraverseVal').innerText = t.horizontalTraverse ?? 0;
   document.getElementById('tankMaxTurretIncline').value = t.maxTurretIncline ?? 0; document.getElementById('maxTurretInclineVal').innerText = t.maxTurretIncline ?? 0;
   document.getElementById('tankMaxTurretDecline').value = t.maxTurretDecline ?? 0; document.getElementById('maxTurretDeclineVal').innerText = t.maxTurretDecline ?? 0;
   document.getElementById('tankBodyWidth').value = t.bodyWidth ?? 1; document.getElementById('bodyWidthVal').innerText = t.bodyWidth ?? 1;
@@ -280,6 +283,7 @@ function clearTankForm() {
   document.getElementById('tankIncline').value = 2; document.getElementById('inclineVal').innerText = '';
   document.getElementById('tankBodyRot').value = 1; document.getElementById('bodyRotVal').innerText = '';
   document.getElementById('tankTurretRot').value = 1; document.getElementById('turretRotVal').innerText = '';
+  document.getElementById('tankHorizontalTraverse').value = 0; document.getElementById('horizontalTraverseVal').innerText = '';
   document.getElementById('tankMaxTurretIncline').value = 0; document.getElementById('maxTurretInclineVal').innerText = '';
   document.getElementById('tankMaxTurretDecline').value = 0; document.getElementById('maxTurretDeclineVal').innerText = '';
   document.getElementById('tankBodyWidth').value = 1; document.getElementById('bodyWidthVal').innerText = '';

--- a/admin/tanks.html
+++ b/admin/tanks.html
@@ -60,6 +60,7 @@
               <th data-sort="crew">Crew</th>
               <th data-sort="engineHp">HP</th>
               <th data-sort="maxSpeed">Speed</th>
+              <th data-sort="horizontalTraverse">Horiz Trav</th>
               <th data-sort="bodyWidth">Body W</th>
               <th data-sort="bodyLength">Body L</th>
               <th data-sort="bodyHeight">Body H</th>
@@ -80,6 +81,7 @@
               <option value="Light/Scout">Light/Scout</option>
               <option value="Medium/MBT">Medium/MBT</option>
               <option value="Heavy">Heavy</option>
+              <option value="Tank Destroyer">Tank Destroyer</option>
             </select>
           </div>
           <div id="tankSections">
@@ -102,6 +104,10 @@
               <label>Turret Rotation Time (s/360°)
                 <input id="tankTurretRot" type="range" min="1" max="60" step="1" oninput="document.getElementById('turretRotVal').innerText=this.value">
                 <span id="turretRotVal"></span>
+              </label>
+              <label>Horizontal Traverse (deg)
+                <input id="tankHorizontalTraverse" type="range" min="0" max="20" step="1" oninput="document.getElementById('horizontalTraverseVal').innerText=this.value">
+                <span id="horizontalTraverseVal"></span>
               </label>
               <label>Max Turret Incline (deg)
                 <input id="tankMaxTurretIncline" type="range" min="0" max="50" step="1" oninput="document.getElementById('maxTurretInclineVal').innerText=this.value">

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -192,6 +192,7 @@ const defaultTank = {
   bodyRotation: 20, // seconds for full rotation
   maxTurretIncline: 50,
   maxTurretDecline: 25,
+  horizontalTraverse: 0,
   bodyWidth: 2,
   bodyLength: 4,
   bodyHeight: 1,
@@ -205,6 +206,7 @@ let MAX_REVERSE_SPEED = defaultTank.maxReverseSpeed / 3.6; // convert km/h to m/
 let ROT_SPEED = (2 * Math.PI) / defaultTank.bodyRotation; // radians per second
 let MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretIncline);
 let MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretDecline);
+let MAX_TURRET_TRAVERSE = Infinity; // radians; Infinity allows full rotation
 // Acceleration used when W/S are pressed. Tuned so max speed is reached in a few seconds.
 let ACCELERATION = MAX_SPEED / 3;
 let currentSpeed = 0;
@@ -415,6 +417,8 @@ function applyTankConfig(t) {
   ROT_SPEED = (2 * Math.PI) / (t.bodyRotation ?? defaultTank.bodyRotation);
   MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(t.maxTurretIncline ?? defaultTank.maxTurretIncline);
   MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(t.maxTurretDecline ?? defaultTank.maxTurretDecline);
+  const traverseDeg = t.horizontalTraverse ?? defaultTank.horizontalTraverse;
+  MAX_TURRET_TRAVERSE = traverseDeg === 0 ? Infinity : THREE.MathUtils.degToRad(traverseDeg);
   ACCELERATION = MAX_SPEED / 3;
 
   tank.geometry.dispose();
@@ -452,7 +456,8 @@ function applyTankConfig(t) {
 
 function onMouseMove(e) {
   const sensitivity = 0.002;
-  turret.rotation.y -= e.movementX * sensitivity;
+  const newYaw = turret.rotation.y - e.movementX * sensitivity;
+  turret.rotation.y = THREE.MathUtils.clamp(newYaw, -MAX_TURRET_TRAVERSE, MAX_TURRET_TRAVERSE);
   turret.rotation.x = THREE.MathUtils.clamp(
     turret.rotation.x - e.movementY * sensitivity,
     -MAX_TURRET_DECLINE,

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -362,7 +362,7 @@ app.get('/api/stats', requireAuth, (req, res) => {
 });
 
 // Admin CRUD endpoints with validation helpers
-const classes = new Set(['Light/Scout', 'Medium/MBT', 'Heavy']);
+const classes = new Set(['Light/Scout', 'Medium/MBT', 'Heavy', 'Tank Destroyer']);
 const ammoChoices = new Set(['HE', 'HEAT', 'AP', 'Smoke']);
 const ammoTypes = new Set(['HE', 'HEAT', 'AP', 'Smoke']);
 
@@ -388,6 +388,8 @@ function validateTank(t) {
   if (typeof t.turretRotation !== 'number' || t.turretRotation < 1 || t.turretRotation > 60) return 'invalid turret rotation';
   if (typeof t.maxTurretIncline !== 'number' || t.maxTurretIncline < 0 || t.maxTurretIncline > 50 || t.maxTurretIncline % 1 !== 0) return 'invalid turret incline';
   if (typeof t.maxTurretDecline !== 'number' || t.maxTurretDecline < 0 || t.maxTurretDecline > 25 || t.maxTurretDecline % 1 !== 0) return 'invalid turret decline';
+  if (!Number.isInteger(t.horizontalTraverse) || t.horizontalTraverse < 0 || t.horizontalTraverse > 20)
+    return 'invalid horizontal traverse';
   if (typeof t.bodyWidth !== 'number' || t.bodyWidth < 1 || t.bodyWidth > 5 || (t.bodyWidth * 4) % 1 !== 0) return 'invalid body width';
   if (typeof t.bodyLength !== 'number' || t.bodyLength < 1 || t.bodyLength > 10 || (t.bodyLength * 4) % 1 !== 0) return 'invalid body length';
   if (typeof t.bodyHeight !== 'number' || t.bodyHeight < 1 || t.bodyHeight > 3 || (t.bodyHeight * 4) % 1 !== 0) return 'invalid body height';
@@ -411,6 +413,7 @@ function validateTank(t) {
     turretRotation: t.turretRotation,
     maxTurretIncline: t.maxTurretIncline,
     maxTurretDecline: t.maxTurretDecline,
+    horizontalTraverse: t.horizontalTraverse,
     bodyWidth: t.bodyWidth,
     bodyLength: t.bodyLength,
     bodyHeight: t.bodyHeight,


### PR DESCRIPTION
## Summary
- support new Tank Destroyer class and horizontal traverse limits on server
- expose horizontal traverse control in admin UI and include in tank CRUD
- clamp client turret rotation using optional horizontal traverse field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad628753c4832895015b4ef213a1d3