### PR TITLE
Refactor terrain editor tools with dedicated tabs

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,5 +1,5 @@
 /* admin.css
-   Summary: Styling for Tanks admin pages with tank-themed cards, forms, sidebar navigation, terrain tables and 3D terrain editor layout.
+   Summary: Styling for Tanks admin pages with tank-themed cards, forms, sidebar navigation, terrain tables and 3D terrain editor layout including tabbed tools.
    Structure: flex layout with sidebar, reusable card styles and chart container for statistics.
    Usage: Linked by all files in /admin for admin panel styling. */
 
@@ -76,27 +76,52 @@ body {
 /* Layout for terrain editor controls and previews */
 #editorCard {
   display: flex;
-  flex-wrap: wrap;
   gap: 20px;
+  height: calc(100vh - 140px);
 }
 
 #editorControls {
-  flex: 1;
+  flex: 0 0 320px;
   min-width: 220px;
-  max-width: 280px;
+  max-width: 320px;
+  overflow-y: auto;
 }
 
 #editorViews {
-  flex: 2;
+  flex: 1;
   min-width: 300px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
 }
 #editorViews #terrain3d {
   width: 100%;
-  /* enlarged 3D preview for better terrain detail */
-  height: 400px;
+  flex: 1;
+  /* expanded 3D preview fills remaining space */
+  min-height: 400px;
+}
+
+#toolTabs {
+  display: flex;
+  gap: 4px;
+  margin: 10px 0;
+}
+
+.tool-tab {
+  flex: 1;
+  padding: 6px;
+  background: #2b361e;
+  color: #f5f5f5;
+  border: 1px solid #2b361e;
+  cursor: pointer;
+}
+
+.tool-tab.active {
+  background: #3e4b2e;
+  outline: 2px solid #fff;
+}
+
+.tool-panel {
+  margin-bottom: 10px;
 }
 
 .ground-types button {

--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -1,8 +1,9 @@
 <!-- terrain.html
      Summary: Admin page for managing terrain presets with a direct 3D terrain editor that allows
-              clicking on the surface to sculpt ground types and elevation. Includes a Perlin-noise
-              generator with adjustable controls for quickly creating natural-looking landscapes. The
-              3D view renders automatically whenever a map is created or its size/type is changed.
+              clicking on the surface to sculpt ground types, elevation and flag points via separate
+              tool tabs. Includes a Perlin-noise generator with adjustable controls for quickly
+              creating natural-looking landscapes. The 3D view renders automatically whenever a map
+              is created or its size/type is changed.
      Structure: login, navbar with profile menu, sidebar navigation, table of maps with thumbnails
                and an expandable 3D editor featuring camera controls and shading.
      Usage: Visit /admin/terrain.html after logging in to manage terrains and design custom maps. -->
@@ -79,38 +80,62 @@
           <label for="sizeY">Map height (km)</label>
           <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
 
-          <label for="mode">Edit Mode</label>
-          <select id="mode">
-            <option value="ground">Ground</option>
-            <option value="elevation">Elevation</option>
-            <option value="flags">Flags</option>
-          </select>
-          <label for="flagSelect" class="flag-controls" style="display:none">Flag</label>
-          <select id="flagSelect" class="flag-controls" style="display:none">
-            <option value="red-a">Red A</option>
-            <option value="red-b">Red B</option>
-            <option value="red-c">Red C</option>
-            <option value="red-d">Red D</option>
-            <option value="blue-a">Blue A</option>
-            <option value="blue-b">Blue B</option>
-            <option value="blue-c">Blue C</option>
-            <option value="blue-d">Blue D</option>
-          </select>
-          <p id="flagInstructions" class="flag-controls instructions" style="display:none">Select a flag then click the map to place it.</p>
-          <label for="brushSizeX">Brush Size X (cells)</label>
-          <input type="range" id="brushSizeX" min="1" max="10" value="2">
-          <label for="brushSizeY">Brush Size Y (cells)</label>
-          <input type="range" id="brushSizeY" min="1" max="10" value="2">
-          <label for="brushSizeZ">Brush Height</label>
-          <input type="range" id="brushSizeZ" min="1" max="20" value="5">
+          <div id="toolTabs">
+            <button data-mode="ground" class="tool-tab active">Ground</button>
+            <button data-mode="elevation" class="tool-tab">Elevation</button>
+            <button data-mode="flags" class="tool-tab">Flags</button>
+          </div>
 
-          <label for="perlinScale">Perlin Scale</label>
-          <input type="number" id="perlinScale" min="1" max="100" value="10">
+          <div id="groundControls" class="tool-panel active">
+            <label for="gBrushSizeX">Brush Size X (cells)</label>
+            <input type="range" id="gBrushSizeX" min="1" max="10" value="2">
+            <label for="gBrushSizeY">Brush Size Y (cells)</label>
+            <input type="range" id="gBrushSizeY" min="1" max="10" value="2">
 
-          <label for="perlinAmplitude">Perlin Amplitude</label>
-          <input type="number" id="perlinAmplitude" min="1" max="100" value="100">
+            <h3>Ground Types</h3>
+            <div id="groundTypesList" class="ground-types"></div>
+            <label for="groundName">Name</label>
+            <input id="groundName" placeholder="e.g. gravel">
+            <label for="groundColor">Color</label>
+            <input id="groundColor" type="color" value="#777777">
+            <label for="groundTraction">Traction (0-1)</label>
+            <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
+            <label for="groundViscosity">Viscosity (0-1)</label>
+            <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
+            <button id="addGroundBtn">Add Ground Type</button>
+          </div>
 
-          <button id="perlinBtn">Generate Perlin Terrain</button>
+          <div id="elevationControls" class="tool-panel" style="display:none">
+            <label for="eBrushSizeX">Brush Size X (cells)</label>
+            <input type="range" id="eBrushSizeX" min="1" max="10" value="2">
+            <label for="eBrushSizeY">Brush Size Y (cells)</label>
+            <input type="range" id="eBrushSizeY" min="1" max="10" value="2">
+            <label for="eBrushSizeZ">Brush Height</label>
+            <input type="range" id="eBrushSizeZ" min="1" max="20" value="5">
+
+            <label for="perlinScale">Perlin Scale</label>
+            <input type="number" id="perlinScale" min="1" max="100" value="10">
+
+            <label for="perlinAmplitude">Perlin Amplitude</label>
+            <input type="number" id="perlinAmplitude" min="1" max="100" value="100">
+
+            <button id="perlinBtn">Generate Perlin Terrain</button>
+          </div>
+
+          <div id="flagControls" class="tool-panel" style="display:none">
+            <label for="flagSelect">Flag</label>
+            <select id="flagSelect">
+              <option value="red-a">Red A</option>
+              <option value="red-b">Red B</option>
+              <option value="red-c">Red C</option>
+              <option value="red-d">Red D</option>
+              <option value="blue-a">Blue A</option>
+              <option value="blue-b">Blue B</option>
+              <option value="blue-c">Blue C</option>
+              <option value="blue-d">Blue D</option>
+            </select>
+            <p class="instructions">Select a flag then click the map to place it.</p>
+          </div>
 
           <label for="showAxes">Show Axes</label>
           <input type="checkbox" id="showAxes" checked>
@@ -130,17 +155,6 @@
           <label for="lockCamera">Lock Position</label>
           <input type="checkbox" id="lockCamera">
 
-          <h3>Ground Types</h3>
-          <div id="groundTypesList" class="ground-types"></div>
-          <label for="groundName">Name</label>
-          <input id="groundName" placeholder="e.g. gravel">
-          <label for="groundColor">Color</label>
-          <input id="groundColor" type="color" value="#777777">
-          <label for="groundTraction">Traction (0-1)</label>
-          <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
-          <label for="groundViscosity">Viscosity (0-1)</label>
-          <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
-          <button id="addGroundBtn">Add Ground Type</button>
           <button id="saveTerrainBtn">Save Map</button>
           <button id="cancelEditBtn">Cancel</button>
         </div>


### PR DESCRIPTION
## Summary
- Split terrain editor into separate ground, elevation, and flag tabs
- Preserve Plotly interaction by updating the 3D plot with `Plotly.react`
- Expand editor layout to use available page space more effectively

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad724e693483289c5817128fc1ee82