### PR TITLE
style: enlarge splash screen to 80% viewport

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -32,6 +32,10 @@ body {
   border-radius: 6px;
   text-align: center;
   z-index: 1000;
+  /* Occupy 80% of the viewport to create a prominent splash screen */
+  width: 80vw;
+  height: 80vh;
+  overflow: auto;
 }
 
 #selectionRow {
@@ -127,6 +131,10 @@ canvas { display: block; }
   border-radius: 6px;
   text-align: center;
   z-index: 1000;
+  /* Match splash screen size: cover 80% of viewport */
+  width: 80vw;
+  height: 80vh;
+  overflow: auto;
 }
 #authContainer input {
   margin: 5px;


### PR DESCRIPTION
## Summary
- enlarge lobby and auth splash overlays to occupy 80% of the screen
- allow scrolling within enlarged overlays for overflow content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9dbce89483289cf389844433bf04