### PR TITLE
Replace flag images with searchable flag emojis

### DIFF
--- a/admin/flag-utils.js
+++ b/admin/flag-utils.js
@@ -1,0 +1,27 @@
+// flag-utils.js
+// Summary: Generates a list of ISO country codes with corresponding flag emojis.
+// Structure: helper to convert country code -> emoji, generator using Intl APIs -> export.
+// Usage: Imported by admin.js to populate flag emoji datalist for nation selection.
+// ---------------------------------------------------------------------------
+
+// Convert an ISO 3166-1 alpha-2 country code into its flag emoji.
+export function codeToFlagEmoji(code) {
+  return code
+    .toUpperCase()
+    .replace(/./g, c => String.fromCodePoint(127397 + c.charCodeAt(0)));
+}
+
+// Build [{code,name,emoji}] list using Intl APIs with graceful fallback.
+export function getFlagList() {
+  const display = typeof Intl.DisplayNames === 'function'
+    ? new Intl.DisplayNames(['en'], { type: 'region' })
+    : null;
+  const regions = typeof Intl.supportedValuesOf === 'function'
+    ? Intl.supportedValuesOf('region').filter(c => c.length === 2)
+    : ['US', 'GB', 'DE', 'FR', 'JP']; // minimal fallback
+  return regions.map(code => ({
+    code,
+    name: display ? display.of(code) : code,
+    emoji: codeToFlagEmoji(code)
+  }));
+}

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -1,7 +1,8 @@
 <!-- nations.html
-     Summary: Admin page for creating and editing nations with flag uploads.
+     Summary: Admin page for creating and editing nations with flag emoji selection.
      Structure: login, navbar with profile menu, sidebar navigation and nation CRUD card.
-     Usage: Visit /admin/nations.html after logging in. -->
+     Usage: Visit /admin/nations.html after logging in. Choose a flag emoji from the list
+            to represent each nation. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -45,10 +46,11 @@
     <main id="mainContent">
       <section class="card">
         <h2>Nations</h2>
-        <p class="instructions">Add, edit or delete nations. Upload a flag image to represent each nation.</p>
+        <p class="instructions">Add, edit or delete nations. Select a flag emoji to represent each nation.</p>
         <div id="nationList"></div>
         <input id="nationName" placeholder="Name">
-        <input type="file" id="nationFlag" accept="image/*">
+        <input id="nationFlag" placeholder="Flag" list="flagOptions">
+        <datalist id="flagOptions"></datalist>
         <button id="addNationBtn">Add Nation</button>
       </section>
     </main>

--- a/public/styles.css
+++ b/public/styles.css
@@ -50,14 +50,20 @@ body {
   overflow-y: auto;
 }
 
-#nationColumn img, #tankColumn img {
+#nationColumn .flag, #tankColumn img {
   width: 100%;
   cursor: pointer;
   margin-bottom: 5px;
   border: 2px solid transparent;
+  display: block;
+  text-align: center;
 }
 
-#nationColumn img.selected, #tankColumn img.selected {
+#nationColumn .flag {
+  font-size: 48px;
+}
+
+#nationColumn .flag.selected, #tankColumn img.selected {
   border-color: #fff;
 }
 

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -142,24 +142,25 @@ async function loadLobbyData() {
     ammoDefs = Array.isArray(ammo) ? ammo : [];
     nationColumn.innerHTML = '';
     nations.forEach(n => {
-      const img = document.createElement('img');
-      img.src = n.flag || 'https://placehold.co/64x40?text=Flag';
-      img.alt = n.name;
-      img.addEventListener('click', () => {
+      const div = document.createElement('div');
+      div.className = 'flag selectable';
+      div.textContent = n.flag || '🏳️';
+      div.title = n.name;
+      div.addEventListener('click', () => {
         selectedNation = n;
         renderTanks();
-        highlightSelection(nationColumn, img);
+        highlightSelection(nationColumn, div);
       });
-      nationColumn.appendChild(img);
+      nationColumn.appendChild(div);
     });
   } catch (err) {
     showError('Failed to load lobby data');
   }
 }
 
-function highlightSelection(container, img) {
-  container.querySelectorAll('img').forEach(i => i.classList.remove('selected'));
-  img.classList.add('selected');
+function highlightSelection(container, el) {
+  container.querySelectorAll('.selected').forEach(i => i.classList.remove('selected'));
+  el.classList.add('selected');
 }
 
 function renderTanks() {


### PR DESCRIPTION
## Summary
- Replace flag image uploads with searchable flag emoji datalist in nation admin page
- Display selected flag emojis on lobby splash screen and store emoji strings server-side
- Remove flag upload handling from server and update styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada06a469083288ea2037a2711e81b