### PR TITLE
feat(admin): add flag emoji picker to nation CRUD

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -169,6 +169,22 @@ body.login-page {
   pointer-events: all;
 }
 
+/* Nation CRUD layout -------------------------------------------------- */
+#nationTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 15px;
+}
+#nationTable th,
+#nationTable td {
+  border: 1px solid #2b361e;
+  padding: 4px;
+  text-align: left;
+}
+#nationTable .flag-cell {
+  font-size: 1.5em;
+}
+
 /* Table listing of saved terrains with thumbnail previews */
 #terrainTable {
   width: 100%;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -68,20 +68,26 @@ async function loadData() {
   const ammoNation = document.getElementById('ammoNation');
   if (ammoNation) ammoNation.innerHTML = nationOptions;
 
-  // Populate flag emoji datalist for nation form
+  // Populate flag emoji datalist for nation form. Value is the emoji so the
+  // selected symbol is inserted directly into the text box while the option
+  // text remains searchable by country name.
   const flagList = document.getElementById('flagOptions');
   if (flagList) {
-    flagList.innerHTML = FLAG_LIST.map(f => `<option value="${f.name}" label="${f.emoji}"></option>`).join('');
+    flagList.innerHTML = FLAG_LIST
+      .map(f => `<option value="${f.emoji}">${f.name}</option>`) // emoji value, name label
+      .join('');
   }
 
-  // Render nation list
-  const nationDiv = document.getElementById('nationList');
-  if (nationDiv) {
-    nationDiv.innerHTML = nationsCache.map((n, i) =>
-      `<div>${n.flag || ''} ${n.name} <button data-i="${i}" class="edit-nation">Edit</button><button data-i="${i}" class="del-nation">Delete</button></div>`
+  // Render nation list inside a table body for clearer presentation
+  const nationBody = document.getElementById('nationList');
+  if (nationBody) {
+    nationBody.innerHTML = nationsCache.map((n, i) =>
+      `<tr><td class="flag-cell">${n.flag || ''}</td><td>${n.name}</td>` +
+      `<td><button data-i="${i}" class="edit-nation">Edit</button>` +
+      `<button data-i="${i}" class="del-nation">Delete</button></td></tr>`
     ).join('');
-    nationDiv.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
-    nationDiv.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
+    nationBody.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
+    nationBody.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
   }
 
   // Render tank table and enable column sorting
@@ -125,8 +131,11 @@ async function loadData() {
 function collectNationForm() {
   const name = document.getElementById('nationName').value;
   let flag = document.getElementById('nationFlag').value.trim();
-  const found = FLAG_LIST.find(f => f.name === flag);
-  if (found) flag = found.emoji; // convert country name to emoji
+  // Allow users to type a country name, ISO code or pick an emoji directly.
+  const found = FLAG_LIST.find(f =>
+    f.name === flag || f.emoji === flag || f.code === flag.toUpperCase()
+  );
+  if (found) flag = found.emoji; // normalise to emoji
   return { name, flag };
 }
 
@@ -148,8 +157,8 @@ async function addNation() {
 function editNation(i) {
   const n = nationsCache[i];
   document.getElementById('nationName').value = n.name;
-  const match = FLAG_LIST.find(f => f.emoji === n.flag);
-  document.getElementById('nationFlag').value = match ? match.name : n.flag;
+  // Input expects an emoji value so insert the stored flag directly
+  document.getElementById('nationFlag').value = n.flag;
   editingNationIndex = i;
   document.getElementById('addNationBtn').innerText = 'Update Nation';
 }

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -1,8 +1,9 @@
 <!-- nations.html
      Summary: Admin page for creating and editing nations with flag emoji selection.
-     Structure: navbar with profile menu, sidebar navigation and nation CRUD card.
-     Usage: Visit /admin/nations.html to manage nations. Choose a flag emoji from the list
-            to represent each nation. -->
+     Structure: navbar with profile menu, sidebar navigation and a card containing a
+                table of nations and a form for adding/updating entries.
+     Usage: Visit /admin/nations.html to manage nations. Choose a flag emoji from the
+            autocomplete list to represent each nation. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -41,9 +42,15 @@
       <section class="card">
         <h2>Nations</h2>
         <p class="instructions">Add, edit or delete nations. Select a flag emoji to represent each nation.</p>
-        <div id="nationList"></div>
+        <table id="nationTable">
+          <thead>
+            <tr><th>Flag</th><th>Name</th><th>Actions</th></tr>
+          </thead>
+          <tbody id="nationList"></tbody>
+        </table>
         <input id="nationName" placeholder="Name">
         <input id="nationFlag" placeholder="Flag" list="flagOptions">
+        <span class="field-desc">Start typing a country name to pick its flag.</span>
         <datalist id="flagOptions"></datalist>
         <button id="addNationBtn">Add Nation</button>
       </section>


### PR DESCRIPTION
## Summary
- allow selecting country flags via emoji-aware datalist
- display nations in a styled table with larger flag icons
- normalize nation form to store emoji and handle ISO codes

## Testing
- `npm test`
- `node --check admin/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68adefec81e083288682ff7833498f7d