### PR TITLE
Replace flag search with dropdown selection

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -3,7 +3,8 @@
 //          separate admin pages linked by a sidebar. Terrain management now uses a table with
 //          3D thumbnails and an in-page editor. The tank form renders a Three.js-powered 3D
 //          preview with independently rotating chassis and turret based on rotation times, and
-//          range inputs auto-populate mid-scale defaults for consistent layout.
+//          range inputs auto-populate mid-scale defaults for consistent layout. Nation management
+//          uses a drop-down list for choosing flag emojis.
 // Uses secure httpOnly cookie set by server and provides logout and game restart endpoints.
 // Structure: auth helpers -> data loaders -> CRUD functions -> restart helpers -> UI handlers.
 // Usage: Included by all files in /admin.
@@ -68,14 +69,13 @@ async function loadData() {
   const ammoNation = document.getElementById('ammoNation');
   if (ammoNation) ammoNation.innerHTML = nationOptions;
 
-  // Populate flag emoji datalist for nation form. Value is the emoji so the
-  // selected symbol is inserted directly into the text box while the option
-  // text remains searchable by country name.
-  const flagList = document.getElementById('flagOptions');
-  if (flagList) {
-    flagList.innerHTML = FLAG_LIST
-      .map(f => `<option value="${f.emoji}">${f.name}</option>`) // emoji value, name label
-      .join('');
+  // Populate flag emoji dropdown for nation form. Each option's value is the
+  // emoji itself so selecting a flag inserts the symbol directly.
+  const flagSelect = document.getElementById('nationFlag');
+  if (flagSelect) {
+    flagSelect.innerHTML =
+      '<option value="" disabled selected>Select a flag</option>' +
+      FLAG_LIST.map(f => `<option value="${f.emoji}">${f.emoji} ${f.name}</option>`).join('');
   }
 
   // Render nation list inside a table body for clearer presentation
@@ -130,12 +130,8 @@ async function loadData() {
 
 function collectNationForm() {
   const name = document.getElementById('nationName').value;
-  let flag = document.getElementById('nationFlag').value.trim();
-  // Allow users to type a country name, ISO code or pick an emoji directly.
-  const found = FLAG_LIST.find(f =>
-    f.name === flag || f.emoji === flag || f.code === flag.toUpperCase()
-  );
-  if (found) flag = found.emoji; // normalise to emoji
+  // Dropdown stores emoji values directly, making submission straightforward.
+  const flag = document.getElementById('nationFlag').value;
   return { name, flag };
 }
 
@@ -157,7 +153,7 @@ async function addNation() {
 function editNation(i) {
   const n = nationsCache[i];
   document.getElementById('nationName').value = n.name;
-  // Input expects an emoji value so insert the stored flag directly
+  // Select expects an emoji value so set the dropdown accordingly
   document.getElementById('nationFlag').value = n.flag;
   editingNationIndex = i;
   document.getElementById('addNationBtn').innerText = 'Update Nation';
@@ -170,7 +166,8 @@ async function deleteNation(i) {
 
 function clearNationForm() {
   document.getElementById('nationName').value = '';
-  document.getElementById('nationFlag').value = '';
+  // Reset dropdown to placeholder option.
+  document.getElementById('nationFlag').selectedIndex = 0;
 }
 
 function collectTankForm() {

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -3,7 +3,7 @@
      Structure: navbar with profile menu, sidebar navigation and a card containing a
                 table of nations and a form for adding/updating entries.
      Usage: Visit /admin/nations.html to manage nations. Choose a flag emoji from the
-            autocomplete list to represent each nation. -->
+            drop-down list to represent each nation. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -49,9 +49,10 @@
           <tbody id="nationList"></tbody>
         </table>
         <input id="nationName" placeholder="Name">
-        <input id="nationFlag" placeholder="Flag" list="flagOptions">
-        <span class="field-desc">Start typing a country name to pick its flag.</span>
-        <datalist id="flagOptions"></datalist>
+        <select id="nationFlag">
+          <option value="" disabled selected>Select a flag</option>
+        </select>
+        <span class="field-desc">Pick a flag emoji from the list.</span>
         <button id="addNationBtn">Add Nation</button>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- replace non-functional country name search with flag emoji dropdown
- populate nation flags and form processing based on dropdown selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf345466c83289d488570d7077af0