### PR TITLE
Add sortable admin tables with thumbnails

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -181,6 +181,7 @@ body.login-page {
   padding: 4px;
   text-align: left;
 }
+#nationTable th { cursor: pointer; }
 #nationTable .flag-cell {
   font-size: 1.5em;
 }
@@ -220,6 +221,35 @@ body.login-page {
 }
 #tanksTable th {
   cursor: pointer; /* allow sorting */
+}
+
+/* Small top-down preview canvas for tanks */
+.tank-thumb {
+  width: 60px;
+  height: 30px;
+  display: block;
+}
+
+/* Ammo CRUD layout ------------------------------------------------------- */
+#ammoTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 15px;
+}
+#ammoTable th,
+#ammoTable td {
+  border: 1px solid #2b361e;
+  padding: 4px;
+  text-align: left;
+}
+#ammoTable th {
+  cursor: pointer;
+}
+.ammo-thumb {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  display: block;
 }
 
 #tankForm .form-row {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -48,8 +48,14 @@ let editingAmmoIndex = null;
 let editingTerrainIndex = null;
 let currentTerrainIndex = 0;
 let tankNationChart = null;
+
+// Table sorting state
 let tankSortKey = 'name';
 let tankSortAsc = true;
+let nationSortKey = 'name';
+let nationSortAsc = true;
+let ammoSortKey = 'name';
+let ammoSortAsc = true;
 let previewRenderer, previewScene, previewCamera, previewTankGroup, previewTurret, previewClock;
 const FLAG_LIST = getFlagList();
 
@@ -78,19 +84,16 @@ async function loadData() {
       FLAG_LIST.map(f => `<option value="${f.emoji}">${f.emoji} ${f.name}</option>`).join('');
   }
 
-  // Render nation list inside a table body for clearer presentation
-  const nationBody = document.getElementById('nationList');
-  if (nationBody) {
-    nationBody.innerHTML = nationsCache.map((n, i) =>
-      `<tr><td class="flag-cell">${n.flag || ''}</td><td>${n.name}</td>` +
-      `<td><button data-i="${i}" class="edit-nation">Edit</button>` +
-      `<button data-i="${i}" class="del-nation">Delete</button></td></tr>`
-    ).join('');
-    nationBody.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
-    nationBody.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
-  }
+  // Render lists on each page
+  const nationHeaders = document.querySelectorAll('#nationTable th[data-sort]');
+  nationHeaders.forEach(th => th.onclick = () => {
+    const key = th.dataset.sort;
+    if (nationSortKey === key) nationSortAsc = !nationSortAsc; else { nationSortKey = key; nationSortAsc = true; }
+    renderNationTable();
+  });
+  renderNationTable();
 
-  // Render tank table and enable column sorting
+  // Set up tank sorting headers once then draw table
   const tankHeaders = document.querySelectorAll('#tanksTable th[data-sort]');
   tankHeaders.forEach(th => th.onclick = () => {
     const key = th.dataset.sort;
@@ -99,14 +102,14 @@ async function loadData() {
   });
   renderTankTable();
 
-  const ammoDiv = document.getElementById('ammoList');
-  if (ammoDiv) {
-    ammoDiv.innerHTML = ammoCache.map((a, i) =>
-      `<div>${a.name} (${a.nation} - ${a.type}) <button data-i="${i}" class="edit-ammo">Edit</button><button data-i="${i}" class="del-ammo">Delete</button></div>`
-    ).join('');
-    ammoDiv.querySelectorAll('.edit-ammo').forEach(btn => btn.addEventListener('click', () => editAmmo(btn.dataset.i)));
-    ammoDiv.querySelectorAll('.del-ammo').forEach(btn => btn.addEventListener('click', () => deleteAmmo(btn.dataset.i)));
-  }
+  // Set up ammo sorting and render table
+  const ammoHeaders = document.querySelectorAll('#ammoTable th[data-sort]');
+  ammoHeaders.forEach(th => th.onclick = () => {
+    const key = th.dataset.sort;
+    if (ammoSortKey === key) ammoSortAsc = !ammoSortAsc; else { ammoSortKey = key; ammoSortAsc = true; }
+    renderAmmoTable();
+  });
+  renderAmmoTable();
 
   // Populate user stats table when on Users page
   const userTable = document.getElementById('userTableBody');
@@ -126,6 +129,28 @@ async function loadData() {
     document.getElementById('editorCard').style.display = 'none';
   }
   updateStats();
+}
+
+function renderNationTable() {
+  const tbody = document.getElementById('nationList');
+  if (!tbody) return;
+  const rows = nationsCache.map((n, i) => ({ n, i }));
+  rows.sort((a, b) => {
+    let av = a.n[nationSortKey];
+    let bv = b.n[nationSortKey];
+    if (typeof av === 'string') av = av.toLowerCase();
+    if (typeof bv === 'string') bv = bv.toLowerCase();
+    if (av < bv) return nationSortAsc ? -1 : 1;
+    if (av > bv) return nationSortAsc ? 1 : -1;
+    return 0;
+  });
+  tbody.innerHTML = rows.map(({ n, i }) =>
+    `<tr><td class="flag-cell">${n.flag || ''}</td><td>${n.name}</td>` +
+    `<td><button data-i="${i}" class="edit-nation">Edit</button>` +
+    `<button data-i="${i}" class="del-nation">Delete</button></td></tr>`
+  ).join('');
+  tbody.querySelectorAll('.edit-nation').forEach(btn => btn.addEventListener('click', () => editNation(btn.dataset.i)));
+  tbody.querySelectorAll('.del-nation').forEach(btn => btn.addEventListener('click', () => deleteNation(btn.dataset.i)));
 }
 
 function collectNationForm() {
@@ -229,6 +254,7 @@ function renderTankTable() {
   });
   tbody.innerHTML = rows.map(({ t, i }) =>
     `<tr>
+      <td><canvas id="tank-thumb-${i}" class="tank-thumb" width="60" height="30" aria-label="Tank thumbnail"></canvas></td>
       <td>${t.name}</td>
       <td>${t.nation}</td>
       <td>${t.br}</td>
@@ -245,8 +271,30 @@ function renderTankTable() {
       <td><button data-i="${i}" class="edit-tank">Edit</button><button data-i="${i}" class="del-tank">Delete</button></td>
     </tr>`
   ).join('');
+  rows.forEach(({ t, i }) => {
+    const canvas = document.getElementById(`tank-thumb-${i}`);
+    if (canvas) drawTankThumb(canvas, t);
+  });
   tbody.querySelectorAll('.edit-tank').forEach(btn => btn.addEventListener('click', () => editTank(btn.dataset.i)));
   tbody.querySelectorAll('.del-tank').forEach(btn => btn.addEventListener('click', () => deleteTank(btn.dataset.i)));
+}
+
+function drawTankThumb(canvas, t) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const scale = Math.min(canvas.width / (t.bodyLength || 1), canvas.height / (t.bodyWidth || 1));
+  const bodyW = (t.bodyLength || 1) * scale;
+  const bodyH = (t.bodyWidth || 1) * scale;
+  const bodyX = (canvas.width - bodyW) / 2;
+  const bodyY = (canvas.height - bodyH) / 2;
+  ctx.fillStyle = '#556b2f';
+  ctx.fillRect(bodyX, bodyY, bodyW, bodyH);
+  const turretW = (t.turretLength || 1) * scale;
+  const turretH = (t.turretWidth || 1) * scale;
+  const turretX = canvas.width / 2 - turretW / 2;
+  const turretY = canvas.height / 2 - turretH / 2;
+  ctx.fillStyle = '#6b8e23';
+  ctx.fillRect(turretX, turretY, turretW, turretH);
 }
 
 function editTank(i) {
@@ -369,6 +417,35 @@ async function updatePreview() {
   previewCamera.lookAt(0, bodyH / 2, 0);
 }
 window.updatePreview = updatePreview;
+
+function renderAmmoTable() {
+  const tbody = document.getElementById('ammoTableBody');
+  if (!tbody) return;
+  const rows = ammoCache.map((a, i) => ({ a, i }));
+  rows.sort((x, y) => {
+    let av = x.a[ammoSortKey];
+    let bv = y.a[ammoSortKey];
+    if (typeof av === 'string') av = av.toLowerCase();
+    if (typeof bv === 'string') bv = bv.toLowerCase();
+    if (av < bv) return ammoSortAsc ? -1 : 1;
+    if (av > bv) return ammoSortAsc ? 1 : -1;
+    return 0;
+  });
+  tbody.innerHTML = rows.map(({ a, i }) =>
+    `<tr>
+      <td>${a.image ? `<img src="${a.image}" alt="${a.name}" class="ammo-thumb">` : ''}</td>
+      <td>${a.name}</td>
+      <td>${a.nation}</td>
+      <td>${a.type}</td>
+      <td>${a.caliber}</td>
+      <td>${a.armorPen}</td>
+      <td>${a.explosionRadius}</td>
+      <td><button data-i="${i}" class="edit-ammo">Edit</button><button data-i="${i}" class="del-ammo">Delete</button></td>
+    </tr>`
+  ).join('');
+  tbody.querySelectorAll('.edit-ammo').forEach(btn => btn.addEventListener('click', () => editAmmo(btn.dataset.i)));
+  tbody.querySelectorAll('.del-ammo').forEach(btn => btn.addEventListener('click', () => deleteAmmo(btn.dataset.i)));
+}
 
 function collectAmmoForm() {
   const fd = new FormData();

--- a/admin/ammo.html
+++ b/admin/ammo.html
@@ -1,6 +1,8 @@
 <!-- ammo.html
      Summary: Admin page for creating and editing ammunition with images.
-     Structure: navbar with profile menu, sidebar navigation and ammo CRUD card.
+     Structure: navbar with profile menu, sidebar navigation and ammo CRUD card
+                containing a sortable table of ammunition with thumbnails and a
+                form for adding or updating entries.
      Usage: Visit /admin/ammo.html to manage ammunition types. -->
 <!DOCTYPE html>
 <html lang="en">
@@ -40,7 +42,21 @@
       <section class="card">
         <h2>Ammo</h2>
         <p class="instructions">Manage ammunition statistics and images.</p>
-        <div id="ammoList"></div>
+        <table id="ammoTable">
+          <thead>
+            <tr>
+              <th>Image</th>
+              <th data-sort="name">Name</th>
+              <th data-sort="nation">Nation</th>
+              <th data-sort="type">Type</th>
+              <th data-sort="caliber">Caliber</th>
+              <th data-sort="armorPen">Pen</th>
+              <th data-sort="explosionRadius">Radius</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody id="ammoTableBody"></tbody>
+        </table>
         <input id="ammoName" placeholder="Name">
         <input type="file" id="ammoImage" accept="image/*">
         <select id="ammoNation"></select>

--- a/admin/nations.html
+++ b/admin/nations.html
@@ -1,7 +1,7 @@
 <!-- nations.html
      Summary: Admin page for creating and editing nations with flag emoji selection.
      Structure: navbar with profile menu, sidebar navigation and a card containing a
-                table of nations and a form for adding/updating entries.
+                sortable table of nations and a form for adding/updating entries.
      Usage: Visit /admin/nations.html to manage nations. Choose a flag emoji from the
             drop-down list to represent each nation. -->
 <!DOCTYPE html>
@@ -44,7 +44,7 @@
         <p class="instructions">Add, edit or delete nations. Select a flag emoji to represent each nation.</p>
         <table id="nationTable">
           <thead>
-            <tr><th>Flag</th><th>Name</th><th>Actions</th></tr>
+            <tr><th data-sort="flag">Flag</th><th data-sort="name">Name</th><th>Actions</th></tr>
           </thead>
           <tbody id="nationList"></tbody>
         </table>

--- a/admin/tanks.html
+++ b/admin/tanks.html
@@ -1,9 +1,10 @@
 <!-- tanks.html
      Summary: Admin page for creating, listing and editing tanks with live preview.
      Structure: navbar with profile menu, sidebar navigation and tank CRUD card
-                containing a sortable table and a multi-column form grouped into
-                Armament, Survivability, Maneuverability and Dimensions sections. The
-                Survivability section now includes chassis and turret armor sliders.
+                containing a sortable table with thumbnails and a multi-column form
+                grouped into Armament, Survivability, Maneuverability and Dimensions
+                sections. The Survivability section now includes chassis and turret
+                armor sliders.
      Usage: Visit /admin/tanks.html to manage tank definitions. Slider values display
             defaults at midpoints to maintain consistent layout. -->
 <!DOCTYPE html>
@@ -47,6 +48,7 @@
         <table id="tanksTable">
           <thead>
             <tr>
+              <th>Thumb</th>
               <th data-sort="name">Name</th>
               <th data-sort="nation">Nation</th>
               <th data-sort="br">BR</th>


### PR DESCRIPTION
## Summary
- add sortable nation table
- include canvas-based tank thumbnails in sortable tank list
- display ammo in sortable table with image previews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec0d81a888328a9d3148981a9b212