### PR TITLE
feat: add tank class tabs and fix lobby layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,8 +1,8 @@
 <!-- index.html
      Summary: Client entry and lobby page for Tanks for Nothing.
-     Structure: lobby with flag, tank and ammo selection columns, then canvas for Three.js rendering and
-                overlay for controls.
-     Usage: Open in browser, choose nation, tank and ammo, then click Join Game to play. -->
+     Structure: Lobby with nation flags, tabbed tank-class selection and ammo sliders, then canvas for
+                Three.js rendering and overlay for controls.
+     Usage: Open in browser, choose nation, pick a tank class and tank, load ammo and click Join Game to play. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -28,7 +28,10 @@
   <div id="lobby">
     <div id="selectionRow">
       <div id="nationColumn"></div>
-      <div id="tankColumn"></div>
+      <div id="tankColumn">
+        <div id="tankTabs"></div>
+        <div id="tankList"></div>
+      </div>
       <div id="ammoColumn"></div>
     </div>
     <button id="joinBtn">Join Game</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -35,36 +35,92 @@ body {
   /* Occupy 80% of the viewport to create a prominent splash screen */
   width: 80vw;
   height: 80vh;
-  overflow: auto;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 #selectionRow {
   display: flex;
   gap: 10px;
   margin-bottom: 10px;
+  flex: 1;
 }
 
 #nationColumn, #tankColumn, #ammoColumn {
   flex: 1;
-  max-height: 200px;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
-#nationColumn .flag, #tankColumn img {
-  width: 100%;
-  cursor: pointer;
-  margin-bottom: 5px;
-  border: 2px solid transparent;
-  display: block;
-  text-align: center;
+#nationColumn {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: flex-start;
+  gap: 5px;
 }
 
 #nationColumn .flag {
   font-size: 48px;
+  cursor: pointer;
+  border: 2px solid transparent;
 }
 
-#nationColumn .flag.selected, #tankColumn img.selected {
+#nationColumn .flag.selected {
   border-color: #fff;
+}
+
+#tankColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#tankTabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5px;
+  margin-bottom: 5px;
+}
+
+#tankTabs .tab {
+  background: #3e4b2e;
+  color: #fff;
+  border: 1px solid #fff;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+#tankTabs .tab.selected {
+  background: #fff;
+  color: #3e4b2e;
+}
+
+#tankList {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5px;
+  flex: 1;
+}
+
+#tankList img {
+  width: 80px;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+#tankList img.selected {
+  border-color: #fff;
+}
+
+#ammoColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
 }
 
 #ammoColumn .ammo-item {

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -1,6 +1,6 @@
 // tanksfornothing-client.js
-// Summary: Browser client for Tanks for Nothing. Provides lobby flag, tank and ammo
-//          selection, renders a dimensioned 3D tank based on server-supplied parameters,
+// Summary: Browser client for Tanks for Nothing. Provides lobby flag, tabbed tank-class
+//          and ammo selection, renders a dimensioned 3D tank based on server-supplied parameters,
 //          handles user input, camera control and firing mechanics, uses Cannon.js for
 //          simple collision physics, force-based tank movement and synchronizes state
 //          with a server via Socket.IO. Camera immediately reflects mouse movement while
@@ -121,6 +121,8 @@ if (window.io) {
 const lobby = document.getElementById('lobby');
 const nationColumn = document.getElementById('nationColumn');
 const tankColumn = document.getElementById('tankColumn');
+const tankTabs = document.getElementById('tankTabs');
+const tankList = document.getElementById('tankList');
 const ammoColumn = document.getElementById('ammoColumn');
 const joinBtn = document.getElementById('joinBtn');
 const lobbyError = document.getElementById('lobbyError');
@@ -129,6 +131,7 @@ let availableTanks = [];
 let ammoDefs = [];
 let selectedNation = null;
 let selectedTank = null;
+let selectedClass = null; // current tank class tab
 const loadout = {};
 
 // Populate lobby columns from server data
@@ -165,12 +168,37 @@ function highlightSelection(container, el) {
 }
 
 function renderTanks() {
-  tankColumn.innerHTML = '';
+  tankTabs.innerHTML = '';
+  tankList.innerHTML = '';
   ammoColumn.innerHTML = '';
   selectedTank = null;
   if (!selectedNation) return;
+
+  // Build tab list from tank classes available to the chosen nation
   const filtered = availableTanks.filter(t => t.nation === selectedNation.name);
-  filtered.forEach(t => {
+  const classes = [...new Set(filtered.map(t => t.class))];
+  selectedClass = classes[0];
+
+  classes.forEach(cls => {
+    const tab = document.createElement('button');
+    tab.textContent = cls;
+    tab.className = 'tab';
+    if (cls === selectedClass) tab.classList.add('selected');
+    tab.addEventListener('click', () => {
+      selectedClass = cls;
+      highlightSelection(tankTabs, tab);
+      renderTankList(filtered.filter(t => t.class === selectedClass));
+    });
+    tankTabs.appendChild(tab);
+  });
+
+  renderTankList(filtered.filter(t => t.class === selectedClass));
+}
+
+// Render clickable tank thumbnails for the active class
+function renderTankList(list) {
+  tankList.innerHTML = '';
+  list.forEach(t => {
     const img = document.createElement('img');
     img.src = t.thumbnail || 'https://placehold.co/80x60?text=Tank';
     img.alt = t.name;
@@ -178,9 +206,9 @@ function renderTanks() {
     img.addEventListener('click', () => {
       selectedTank = t;
       renderAmmo();
-      highlightSelection(tankColumn, img);
+      highlightSelection(tankList, img);
     });
-    tankColumn.appendChild(img);
+    tankList.appendChild(img);
   });
 }
 


### PR DESCRIPTION
## Summary
- reorganize lobby layout to fit nations, tanks and ammo without scrollbars
- introduce tank class tabs for streamlined selection
- style lobby with flexible, tabbed tank list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec1e78610832891fa667fcf7f6fdf