### PR TITLE
fix admin initialization to show tank table

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -711,4 +711,13 @@ async function checkAdmin() {
   window.location.href = 'login.html';
 }
 
-document.addEventListener('DOMContentLoaded', initAdmin);
+// Ensure admin logic always runs. When this module loads after the
+// DOMContentLoaded event has already fired (e.g. cached module at the
+// end of the body), adding a listener would never trigger. Check the
+// document state and call immediately if necessary so the tank table
+// and form handlers are reliably initialised.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initAdmin);
+} else {
+  initAdmin();
+}


### PR DESCRIPTION
## Summary
- ensure admin script initialises immediately when DOM already loaded so tank CRUD UI works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec36a8be48328ac8c246692c86f18