### PR TITLE
fix: apply turret traverse only to tank destroyers

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -197,11 +197,12 @@ function clearNationForm() {
 }
 
 function collectTankForm() {
+  const cls = document.getElementById('tankClass').value;
   return {
     name: document.getElementById('tankName').value,
     nation: document.getElementById('tankNation').value,
     br: parseFloat(document.getElementById('tankBR').value),
-    class: document.getElementById('tankClass').value,
+    class: cls,
     armor: parseInt(document.getElementById('tankChassisArmor').value, 10),
     turretArmor: parseInt(document.getElementById('tankTurretArmor').value, 10),
     cannonCaliber: parseInt(document.getElementById('tankCaliber').value, 10),
@@ -214,7 +215,10 @@ function collectTankForm() {
     incline: parseInt(document.getElementById('tankIncline').value, 10),
     bodyRotation: parseInt(document.getElementById('tankBodyRot').value, 10),
     turretRotation: parseInt(document.getElementById('tankTurretRot').value, 10),
-    horizontalTraverse: parseInt(document.getElementById('tankHorizontalTraverse').value, 10),
+    // Only retain horizontal traverse input for tank destroyers; other classes rotate freely.
+    horizontalTraverse: cls === 'Tank Destroyer'
+      ? parseInt(document.getElementById('tankHorizontalTraverse').value, 10)
+      : 0,
     maxTurretIncline: parseInt(document.getElementById('tankMaxTurretIncline').value, 10),
     maxTurretDecline: parseInt(document.getElementById('tankMaxTurretDecline').value, 10),
     bodyWidth: parseFloat(document.getElementById('tankBodyWidth').value),

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -299,7 +299,9 @@ let TURRET_ROT_SPEED = (2 * Math.PI) / defaultTank.turretRotation; // turret rad
 let TURN_TORQUE = 0;
 let MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretIncline);
 let MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(defaultTank.maxTurretDecline);
-let MAX_TURRET_TRAVERSE = Infinity; // radians; Infinity allows full rotation
+// Turret traverse limit in radians. Non-tank-destroyers keep Infinity to allow
+// unrestricted rotation, while tank destroyers use their defined limits.
+let MAX_TURRET_TRAVERSE = Infinity;
 // Acceleration used when W/S are pressed. Tuned so max speed is reached in a few seconds.
 let ACCELERATION = MAX_SPEED / 3;
 let currentSpeed = 0;
@@ -526,8 +528,13 @@ function applyTankConfig(t) {
   TURRET_ROT_SPEED = (2 * Math.PI) / (t.turretRotation ?? defaultTank.turretRotation);
   MAX_TURRET_INCLINE = THREE.MathUtils.degToRad(t.maxTurretIncline ?? defaultTank.maxTurretIncline);
   MAX_TURRET_DECLINE = THREE.MathUtils.degToRad(t.maxTurretDecline ?? defaultTank.maxTurretDecline);
-  const traverseDeg = t.horizontalTraverse ?? defaultTank.horizontalTraverse;
-  MAX_TURRET_TRAVERSE = traverseDeg === 0 ? Infinity : THREE.MathUtils.degToRad(traverseDeg);
+  // Only apply horizontal traverse limits for tank destroyers; other classes rotate freely.
+  const traverseDeg =
+    t.class === 'Tank Destroyer'
+      ? t.horizontalTraverse ?? defaultTank.horizontalTraverse
+      : 0;
+  MAX_TURRET_TRAVERSE =
+    traverseDeg === 0 ? Infinity : THREE.MathUtils.degToRad(traverseDeg);
   ACCELERATION = MAX_SPEED / 3;
 
   // Reset orientation targets so camera and turret start aligned for new stats

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -183,7 +183,14 @@ async function safeWriteJson(file, data) {
 
 async function loadTanks() {
   const data = await safeReadJson(TANKS_FILE, { tanks: [] });
-  if (Array.isArray(data.tanks)) tanks = data.tanks;
+  if (Array.isArray(data.tanks)) {
+    // Only tank destroyers should retain a horizontal traverse limit; all other
+    // classes rotate freely so we normalize their value to 0 (meaning unlimited).
+    tanks = data.tanks.map(t => ({
+      ...t,
+      horizontalTraverse: t.class === 'Tank Destroyer' ? t.horizontalTraverse : 0
+    }));
+  }
 }
 
 async function saveTanks() {
@@ -487,7 +494,8 @@ function validateTank(t) {
     turretRotation: t.turretRotation,
     maxTurretIncline: t.maxTurretIncline,
     maxTurretDecline: t.maxTurretDecline,
-    horizontalTraverse: t.horizontalTraverse,
+    // Preserve traverse limits only for tank destroyers; others rotate freely.
+    horizontalTraverse: t.class === 'Tank Destroyer' ? t.horizontalTraverse : 0,
     bodyWidth: t.bodyWidth,
     bodyLength: t.bodyLength,
     bodyHeight: t.bodyHeight,

--- a/tests/turret-traverse.test.js
+++ b/tests/turret-traverse.test.js
@@ -1,0 +1,34 @@
+// turret-traverse.test.js
+// Summary: Verifies that only tank destroyers retain horizontal turret traverse limits.
+// Structure: spawn server -> fetch tank list -> assert non-TDs report 0 traverse and TDs keep their limit.
+// Usage: run with `npm test` which executes `node --test`.
+// ---------------------------------------------------------------------------
+import test from 'node:test';
+import assert from 'node:assert';
+
+process.env.PORT = 0; // use random available port
+const { server } = await import('../tanksfornothing-server.js');
+await new Promise(resolve => server.on('listening', resolve));
+const base = `http://localhost:${server.address().port}`;
+
+test.after(() => server.close());
+
+// Helper to fetch tank data once
+async function getTanks() {
+  const res = await fetch(`${base}/api/tanks`);
+  return res.json();
+}
+
+test('non tank destroyers rotate freely', async () => {
+  const list = await getTanks();
+  const nonTD = list.find(t => t.class !== 'Tank Destroyer');
+  assert.ok(nonTD, 'expected at least one non-tank-destroyer');
+  assert.strictEqual(nonTD.horizontalTraverse, 0);
+});
+
+test('tank destroyers retain traverse limit', async () => {
+  const list = await getTanks();
+  const td = list.find(t => t.class === 'Tank Destroyer');
+  assert.ok(td, 'expected at least one tank destroyer');
+  assert.ok(td.horizontalTraverse > 0);
+});


### PR DESCRIPTION
## Summary
- enforce horizontal traverse limits only for tank destroyers
- default other tanks to full rotation and sanitize admin input
- add regression test for turret traverse limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec4dde110832895089af930340b6b