### PR TITLE
Handle missing Plotly for terrain page thumbnails

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -620,6 +620,13 @@ function renderTerrainTable() {
 function renderThumbnail(id, terrain) {
   const el = document.getElementById(id);
   if (!el) return;
+  // Plotly is loaded via CDN on terrain.html. If the network fails or the
+  // library is missing, skip rendering to avoid a fatal ReferenceError that
+  // would hide the entire terrain table.
+  if (typeof Plotly === 'undefined') {
+    el.textContent = 'preview unavailable';
+    return;
+  }
   const z = [
     [0, 0],
     [0, 0]


### PR DESCRIPTION
## Summary
- Avoid crashing the terrain admin page when the Plotly library fails to load by skipping thumbnail rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec56cd8908328906fbed2b09ac595