### PR TITLE
Improve terrain editor resilience and guidance

### DIFF
--- a/admin/terrain.html
+++ b/admin/terrain.html
@@ -44,6 +44,7 @@
         <h2>Terrain</h2>
         <p class="instructions">Manage saved maps. Click Add to create a new map or Edit to modify.</p>
         <button id="newTerrainBtn">Add Map</button>
+        <p id="noTerrainMsg" class="instructions" style="display:none">No terrains loaded. Click 'Add Map' to open editor.</p>
         <table id="terrainTable">
           <thead>
             <tr><th>Preview</th><th>Type</th><th>Size (km)</th><th>Name</th><th>Actions</th></tr>


### PR DESCRIPTION
## Summary
- Guard terrain loading and editor operations with centralized error handling
- Indicate when no terrains are available and auto-open the editor for new maps
- Show clear on-screen prompt to create a map when none exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af09f4b1cc832898d2db357b19aa83