### PR TITLE
Fix Add Map button opening editor

### DIFF
--- a/admin/map-crud.js
+++ b/admin/map-crud.js
@@ -1,13 +1,28 @@
 // map-crud.js
-// Summary: Wires improved Map CRUD UI, offering a cancel button and debug hooks for the editor.
-// Structure: DOMContentLoaded listener -> cancel handler -> debug logging.
-// Usage: Imported by map-crud.html to enhance terrain editor workflow.
+// Summary: Wires the Map CRUD UI, enabling opening and cancellation of the map editor and emitting
+//          debug info.
+// Structure: DOMContentLoaded listener -> add/cancel handlers -> debug logging.
+// Usage: Imported by map-crud.html; click "Add Map" to open the editor or "Cancel" to close.
 
 'use strict';
 
 console.debug('map-crud.js loaded');
 
 document.addEventListener('DOMContentLoaded', () => {
+  const add = document.getElementById('newTerrainBtn');
+  if (add) {
+    add.addEventListener('click', () => {
+      // Ensure form starts clean, then reveal editor and notify listeners
+      if (typeof window.clearTerrainForm === 'function') {
+        window.clearTerrainForm();
+      }
+      const card = document.getElementById('editorCard');
+      if (card) card.style.display = 'flex';
+      document.dispatchEvent(new Event('terrain-editor-opened'));
+      console.debug('Map editor opened');
+    });
+  }
+
   const cancel = document.getElementById('cancelTerrainBtn');
   if (cancel) {
     cancel.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure Add Map button opens editor and resets form

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: Cannot use keyword 'await' outside an async function, 1325 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b02824a3a48328891416bd9553489e