### PR TITLE
Fix map CRUD layout and restore 3D terrain tools

### DIFF
--- a/admin/map-crud.html
+++ b/admin/map-crud.html
@@ -56,84 +56,135 @@
 
         <section class="card" id="editorCard" style="display:none">
           <h2>Map Editor</h2>
-          <p class="instructions">Map preview updates automatically when size or terrain type changes. Use Cancel to close without saving.</p>
-          <label for="terrainName">Name</label>
-          <input id="terrainName" placeholder="Name">
-          <p class="field-desc">Unique label used to identify the map.</p>
 
-          <label for="terrainType">Terrain Type</label>
-          <select id="terrainType">
-            <option value="snow">Snow</option>
-            <option value="jungle">Jungle</option>
-            <option value="desert">Desert</option>
-            <option value="fields">Fields</option>
-          </select>
-          <p class="field-desc">Base environment preset determining default ground and textures.</p>
+          <div id="editorControls">
+            <p class="instructions">Map preview updates automatically when size or terrain type changes.</p>
+            <label for="terrainName">Name</label>
+            <input id="terrainName" placeholder="Name">
+            <p class="field-desc">Unique label used to identify the map.</p>
 
-          <label for="sizeX">Map width (km)</label>
-          <input type="number" id="sizeX" min="0.1" step="0.1" value="1">
-          <p class="field-desc">Horizontal size of the map in kilometers.</p>
+            <label for="terrainType">Terrain Type</label>
+            <select id="terrainType">
+              <option value="snow">Snow</option>
+              <option value="jungle">Jungle</option>
+              <option value="desert">Desert</option>
+              <option value="fields">Fields</option>
+            </select>
+            <p class="field-desc">Base environment preset determining default ground and textures.</p>
 
-          <label for="sizeY">Map height (km)</label>
-          <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
-          <p class="field-desc">Vertical size of the map in kilometers.</p>
+            <label for="sizeX">Map width (km)</label>
+            <input type="number" id="sizeX" min="0.1" step="0.1" value="1">
+            <p class="field-desc">Horizontal size of the map in kilometers.</p>
 
-          <div id="toolTabs">
-            <button data-mode="ground" class="tool-tab active">Ground</button>
-            <button data-mode="elevation" class="tool-tab">Elevation</button>
-            <button data-mode="flags" class="tool-tab">Flags</button>
-          </div>
+            <label for="sizeY">Map height (km)</label>
+            <input type="number" id="sizeY" min="0.1" step="0.1" value="1">
+            <p class="field-desc">Vertical size of the map in kilometers.</p>
 
-          <div id="groundControls" class="tool-panel">
-            <label for="gBrushSizeX">Brush Size X (cells)</label>
-            <input type="range" id="gBrushSizeX" min="1" max="10" value="2">
+            <div id="toolTabs">
+              <button data-mode="ground" class="tool-tab active">Ground</button>
+              <button data-mode="elevation" class="tool-tab">Elevation</button>
+              <button data-mode="flags" class="tool-tab">Flags</button>
+            </div>
 
-            <label for="gBrushSizeY">Brush Size Y (cells)</label>
-            <input type="range" id="gBrushSizeY" min="1" max="10" value="2">
+            <div id="groundControls" class="tool-panel">
+              <label for="gBrushSizeX">Brush Size X (cells)</label>
+              <input type="range" id="gBrushSizeX" min="1" max="10" value="2">
 
-            <h3>Ground Types</h3>
-            <div id="groundTypesList" class="ground-types"></div>
+              <label for="gBrushSizeY">Brush Size Y (cells)</label>
+              <input type="range" id="gBrushSizeY" min="1" max="10" value="2">
 
-            <label for="groundName">Name</label>
-            <input id="groundName" placeholder="e.g. gravel">
+              <h3>Ground Types</h3>
+              <div id="groundTypesList" class="ground-types"></div>
 
-            <label for="groundColor">Color</label>
-            <input id="groundColor" type="color" value="#777777">
+              <label for="groundName">Name</label>
+              <input id="groundName" placeholder="e.g. gravel">
 
-            <label for="groundTraction">Traction (0-1)</label>
-            <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
+              <label for="groundColor">Color</label>
+              <input id="groundColor" type="color" value="#777777">
 
-            <label for="groundViscosity">Viscosity (0-1)</label>
-            <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
+              <label for="groundTraction">Traction (0-1)</label>
+              <input id="groundTraction" type="number" step="0.1" min="0" max="1" value="0.5">
 
-            <button id="addGroundBtn">Add Ground Type</button>
-          </div>
+              <label for="groundViscosity">Viscosity (0-1)</label>
+              <input id="groundViscosity" type="number" step="0.1" min="0" max="1" value="0.5">
 
-          <div id="elevationControls" class="tool-panel" style="display:none">
-            <label for="eBrushSizeX">Brush Size X (cells)</label>
-            <input type="range" id="eBrushSizeX" min="1" max="10" value="2">
+              <button id="addGroundBtn">Add Ground Type</button>
+            </div>
 
-            <label for="eBrushSizeY">Brush Size Y (cells)</label>
-            <input type="range" id="eBrushSizeY" min="1" max="10" value="2">
-          </div>
+            <div id="elevationControls" class="tool-panel" style="display:none">
+              <label for="eBrushSizeX">Brush Size X (cells)</label>
+              <input type="range" id="eBrushSizeX" min="1" max="10" value="2">
 
-          <div id="flagControls" class="tool-panel" style="display:none">
-            <p>Click on the 3D preview to place capture-the-flag positions.</p>
+              <label for="eBrushSizeY">Brush Size Y (cells)</label>
+              <input type="range" id="eBrushSizeY" min="1" max="10" value="2">
+
+              <label for="eBrushSizeZ">Brush Height</label>
+              <input type="range" id="eBrushSizeZ" min="1" max="20" value="5">
+
+              <label for="perlinScale">Perlin Scale</label>
+              <input type="number" id="perlinScale" min="1" max="100" value="10">
+
+              <label for="perlinAmplitude">Perlin Amplitude</label>
+              <input type="number" id="perlinAmplitude" min="1" max="100" value="100">
+
+              <button id="perlinBtn">Generate Perlin Terrain</button>
+            </div>
+
+            <div id="flagControls" class="tool-panel" style="display:none">
+              <label for="flagSelect">Flag</label>
+              <select id="flagSelect">
+                <option value="red-a">Red A</option>
+                <option value="red-b">Red B</option>
+                <option value="red-c">Red C</option>
+                <option value="red-d">Red D</option>
+                <option value="blue-a">Blue A</option>
+                <option value="blue-b">Blue B</option>
+                <option value="blue-c">Blue C</option>
+                <option value="blue-d">Blue D</option>
+              </select>
+              <p class="instructions">Select a flag then click the map to place it.</p>
+            </div>
+
+            <label for="showAxes">Show Axes</label>
+            <input type="checkbox" id="showAxes" checked>
+            <p class="field-desc">Toggle XYZ axis guides in the preview.</p>
+
+            <label for="viewSelect">View</label>
+            <select id="viewSelect">
+              <option value="iso">Isometric</option>
+              <option value="top">Top</option>
+              <option value="front">Front</option>
+              <option value="side">Side</option>
+            </select>
+            <p class="field-desc">Camera angle for the 3D preview.</p>
+
+            <label for="projectionType">Projection</label>
+            <select id="projectionType">
+              <option value="perspective">Perspective</option>
+              <option value="orthographic">Orthographic</option>
+            </select>
+            <p class="field-desc">Perspective mimics depth; orthographic keeps scale uniform.</p>
+
+            <label for="lockCamera">Lock Position</label>
+            <input type="checkbox" id="lockCamera">
+            <p class="field-desc">Prevent accidental camera movement.</p>
+
+            <button id="saveTerrainBtn">Save Map</button>
+            <button id="cancelTerrainBtn">Cancel</button>
           </div>
 
           <div id="editorViews">
             <div id="terrain3d"></div>
           </div>
-
-          <button id="saveTerrainBtn">Save Map</button>
-          <button id="cancelTerrainBtn">Cancel</button>
         </section>
       </section>
     </main>
   </div>
 
-  <script src="https://cdn.plot.ly/plotly-3.1.0.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.plot.ly/plotly-3.1.0.min.js" crossorigin="anonymous"
+          onerror="this.onerror=null;this.src='/libs/plotly-3.1.0.min.js';"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" crossorigin="anonymous"
+          onerror="this.onerror=null;this.src='/libs/chart-4.5.0.min.js';"></script>
   <script type="module" src="admin.js"></script>
   <script type="module" src="terrain-editor.js"></script>
   <script type="module" src="map-crud.js"></script>


### PR DESCRIPTION
## Summary
- wrap map editor controls in an `#editorControls` container for proper flex layout
- restore ground, elevation, flag, and camera controls so Plotly 3D preview initializes
- add CDN fallbacks for Plotly and Chart.js

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec78473f883289cf4e83d2530fc4d