### PR TITLE
feat: show tank cards in lobby

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -106,14 +106,29 @@ body {
   flex: 1;
 }
 
-#tankList img {
-  width: 80px;
+/* Tank selection cards with thumbnail and caption */
+#tankList .tank-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   cursor: pointer;
   border: 2px solid transparent;
+  padding: 4px;
+  width: 100px;
 }
 
-#tankList img.selected {
+#tankList .tank-card img {
+  width: 80px;
+}
+
+#tankList .tank-card.selected {
   border-color: #fff;
+}
+
+#tankList .tank-caption {
+  margin-top: 2px;
+  font-size: 0.8em;
+  text-align: center;
 }
 
 #ammoColumn {

--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -292,20 +292,35 @@ function renderTanks() {
   renderTankList(filtered.filter(t => t.class === selectedClass));
 }
 
-// Render clickable tank thumbnails for the active class
+// Render clickable tank cards with thumbnail and brief stats for the active class
 function renderTankList(list) {
   tankList.innerHTML = '';
   list.forEach(t => {
+    // Card wrapper allows us to show text alongside the image
+    const card = document.createElement('div');
+    card.className = 'tank-card';
+
+    // Thumbnail with lazy loading for performance; placeholder when none provided
     const img = document.createElement('img');
     img.src = t.thumbnail || 'https://placehold.co/80x60?text=Tank';
     img.alt = t.name;
-    img.title = `${t.name} (BR ${t.br})`;
-    img.addEventListener('click', () => {
+    img.loading = 'lazy';
+
+    // Caption summarising key tank info so users can make an informed choice
+    const caption = document.createElement('div');
+    caption.className = 'tank-caption';
+    caption.textContent = `${t.name} (BR ${t.br})`;
+
+    card.appendChild(img);
+    card.appendChild(caption);
+
+    card.addEventListener('click', () => {
       selectedTank = t;
       renderAmmo();
-      highlightSelection(tankList, img);
+      highlightSelection(tankList, card);
     });
-    tankList.appendChild(img);
+
+    tankList.appendChild(card);
   });
 }
 


### PR DESCRIPTION
## Summary
- render tank thumbnails with names and BR values in lobby
- style lobby list with selectable tank cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5986574a483288b748457650135f3