### PR TITLE
Increase projectile visibility and add firing logs

### DIFF
--- a/public/tanksfornothing-client.js
+++ b/public/tanksfornothing-client.js
@@ -129,7 +129,10 @@ if (window.io) {
   socket.on('terrain', (name) => buildTerrain(name));
   socket.on('projectile-fired', (p) => {
     if (!scene) return;
-    const geom = new THREE.SphereGeometry(0.1, 8, 8);
+    // Debug: log projectile spawn details so firing issues are easier to trace.
+    console.debug('Projectile spawned', p);
+    // Previous shells were too small to see; increase radius for visibility.
+    const geom = new THREE.SphereGeometry(0.3, 12, 12);
     const mat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
     const mesh = new THREE.Mesh(geom, mat);
     mesh.position.set(p.x, p.y, p.z);

--- a/tanksfornothing-server.js
+++ b/tanksfornothing-server.js
@@ -826,6 +826,8 @@ io.on('connection', (socket) => {
     };
     projectiles.set(id, projectile);
     io.emit('projectile-fired', projectile);
+    // Debug: log projectile to server console to trace firing events.
+    console.debug('Projectile fired', projectile);
   });
 
   socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- enlarge client-side projectile mesh for clearer shell visuals and add debug logging
- log fired projectile details on the server for easier debugging of firing events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5cea472a08328b46b6768ccae281f