### PR TITLE
feat: add proxy-aware war thunder importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Set `NODE_ENV=production` when deploying to enable secure cookies.
 Set `ADMIN_PASSWORD` to change the admin login password (default `adminpass`).
 Set `JWT_SECRET` to a long random string to sign authentication tokens.
 
+### Updating tank data from War Thunder
+
+Run `npm run import-wt` to pull ground vehicle definitions from the public War
+Thunder encyclopedia API and write them to `data/tanks.json`. If your network
+requires a proxy, export `HTTPS_PROXY` (or `HTTP_PROXY`) before running the
+import:
+
+```bash
+# Linux / macOS / Raspberry Pi
+HTTPS_PROXY=http://proxy.example.com:3128 npm run import-wt
+
+# Windows PowerShell
+$env:HTTPS_PROXY='http://proxy.example.com:3128'
+npm run import-wt
+```
+
+The script reports connection issues and proxy usage to aid debugging.
+
 ## Usage
  - Create an account at `http://localhost:3000/signup.html` then log in via `http://localhost:3000/login.html`.
  - Open `http://localhost:3000` in a modern browser after logging in to join the battle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "socket.io": "^4.8.1",
-        "three": "^0.179.1"
+        "three": "^0.179.1",
+        "undici": "^7.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
@@ -2482,6 +2483,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "socket.io": "^4.8.1",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "undici": "^7.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",


### PR DESCRIPTION
## Summary
- add proxy support and detailed error logging to War Thunder vehicle importer
- document how to run importer with optional HTTPS proxy
- include undici dependency for proxy-aware fetch

## Testing
- `npm run lint`
- `npm test` *(fails: test failed)*
- `npm run import-wt` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b8ef1be083288a47004f22e7ab6d