### PR TITLE
Fix Colyseus join handshake and auth payload handling

### DIFF
--- a/packages/server/src/game/tanks-room.ts
+++ b/packages/server/src/game/tanks-room.ts
@@ -77,7 +77,7 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
     TanksForNothingRoom.activeRooms.delete(this);
   }
 
-  async onAuth(client: Client, options: JoinOptions, context: AuthContext): Promise<boolean> {
+  async onAuth(client: Client, options: JoinOptions, context: AuthContext): Promise<TanksClientAuth> {
     const auth = this.dependencies.authenticate(context);
     if ('error' in auth) {
       throw new Error(auth.error);
@@ -101,13 +101,14 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
     const ammoCapacity = Number.isFinite(tank.ammoCapacity) ? Number(tank.ammoCapacity) : 0;
     const ammoRemaining = totalLoadout > 0 ? Math.min(totalLoadout, ammoCapacity || totalLoadout) : ammoCapacity;
 
-    (client as Client & { auth: TanksClientAuth }).auth = {
+    const authPayload = {
       username: auth.username,
       tank,
       loadout,
       ammoRemaining
     } satisfies TanksClientAuth;
-    return true;
+    (client as Client & { auth: TanksClientAuth }).auth = authPayload;
+    return authPayload;
   }
 
   onJoin(client: Client, _options: JoinOptions): void {


### PR DESCRIPTION
## Summary
- allow the Colyseus WebSocket transport to accept dynamic room URLs by removing the strict `/colyseus` path restriction and document the reasoning
- return the computed authentication payload from the room `onAuth` hook so spawned players retain their selected tank configuration

## Testing
- npm run build --workspace @tanksfornothing/server
- node - <<'NODE'
import { Client } from 'colyseus.js';

const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QiLCJpYXQiOjE3NjE1Nzk2NzksImV4cCI6MTc2MjE4NDQ3OX0.Ct1eSCZG8PkyE6PPOeudm2wcaPnNQxTnILR91woTHOU';

const client = new Client('ws://127.0.0.1:3000/colyseus', {
  headers: {
    Cookie: `token=${token}`
  }
});

async function main() {
  try {
    const room = await client.joinOrCreate('tanksfornothing', {
      tank: { name: 'M2A4', nation: 'USA' },
      loadout: { AP: 5 }
    });
    console.log('joined room', room.sessionId);
    await room.leave();
    process.exit(0);
  } catch (err) {
    console.error('join failed', err);
    process.exit(1);
  }
}

main();
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ff8f918c0883288f0f87c4effa4803