### PR TITLE
Fix client main entrypoint closing brace

### DIFF
--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1465,3 +1465,4 @@ function updateCamera() {
     camera.lookAt(camera.position.clone().add(look));
   }
 }
+}


### PR DESCRIPTION
## Summary
- add the missing closing brace to the client entrypoint to restore valid syntax

## Testing
- npx eslint packages/client/src/main.ts *(fails: missing typescript-eslint dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe394ded08328b281c42e608643ca