### PR TITLE
Fix client build failure caused by unmatched brace

### DIFF
--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1465,4 +1465,3 @@ function updateCamera() {
     camera.lookAt(camera.position.clone().add(look));
   }
 }
-}


### PR DESCRIPTION
## Summary
- remove the stray closing brace at the end of packages/client/src/main.ts so the module parses correctly

## Testing
- npm run build --workspace @tanksfornothing/client *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe53c7b98832891e2d1ecb632563a