### PR TITLE
Fix terrain scratch init error and expose shared source to Vite

### DIFF
--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -139,6 +139,22 @@ let groundTexture = null;
 // clamp player spawns onto the surface even when the admin-provided heightmaps
 // sit entirely above or below world origin.
 let terrainHeightData = null;
+// Scratch vectors reused when aligning the tank chassis to sampled terrain normals.
+// Declared early so helper functions invoked during initial terrain load can safely
+// access the reused buffers without tripping Temporal Dead Zone rules for const.
+const terrainScratch = {
+  tangentX: new THREE.Vector3(),
+  tangentZ: new THREE.Vector3(),
+  normal: new THREE.Vector3(),
+  up: new THREE.Vector3(),
+  forward: new THREE.Vector3(),
+  projectedForward: new THREE.Vector3(),
+  right: new THREE.Vector3(),
+  temp: new THREE.Vector3(),
+  rotationMatrix: new THREE.Matrix4(),
+  targetQuat: new THREE.Quaternion(),
+  bodyQuat: new THREE.Quaternion()
+};
 
 // Build a simplified tank mesh for remote players using dimensions from the
 // server. These meshes are purely visual and have no physics bodies.
@@ -859,21 +875,6 @@ function sampleTerrainHeightAt(x, z) {
   const h1 = THREE.MathUtils.lerp(h01, h11, tx);
   return THREE.MathUtils.lerp(h0, h1, tz);
 }
-
-// Scratch vectors reused for terrain alignment to avoid per-frame allocations.
-const terrainScratch = {
-  tangentX: new THREE.Vector3(),
-  tangentZ: new THREE.Vector3(),
-  normal: new THREE.Vector3(),
-  up: new THREE.Vector3(),
-  forward: new THREE.Vector3(),
-  projectedForward: new THREE.Vector3(),
-  right: new THREE.Vector3(),
-  temp: new THREE.Vector3(),
-  rotationMatrix: new THREE.Matrix4(),
-  targetQuat: new THREE.Quaternion(),
-  bodyQuat: new THREE.Quaternion()
-};
 
 // Compute an approximate terrain normal using central differences so we can tilt
 // the chassis to match the slope even without reliable physics contacts.

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig(({ mode }) => {
   const host = env.CLIENT_HOST ?? '0.0.0.0';
   const port = Number(env.CLIENT_PORT ?? env.PORT ?? '5173');
   const previewPort = Number(env.CLIENT_PREVIEW_PORT ?? env.PREVIEW_PORT ?? '4173');
+  const sharedSrcDir = resolve(__dirname, '../shared/src');
+  const sharedEntry = resolve(sharedSrcDir, 'index.ts');
 
   return {
     root: rootDir,
@@ -48,7 +50,8 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
-        '/src': srcDir
+        '/src': srcDir,
+        '@tanksfornothing/shared': sharedEntry
       }
     },
     server: {
@@ -57,7 +60,7 @@ export default defineConfig(({ mode }) => {
       strictPort: false,
       open: env.CLIENT_OPEN_BROWSER === 'true',
       fs: {
-        allow: [srcDir, resolve(__dirname)]
+        allow: [srcDir, sharedSrcDir, resolve(__dirname)]
       }
     },
     preview: {


### PR DESCRIPTION
## Summary
- allow the client build to resolve `@tanksfornothing/shared` by aliasing the workspace source in the Vite config
- declare the reusable terrain scratch vectors before any terrain helpers run so the browser no longer raises a temporal dead-zone error during startup

## Testing
- npm run build --workspace @tanksfornothing/client

------
https://chatgpt.com/codex/tasks/task_e_6900b2b007948328957cf2f2847de73d