### PR TITLE
Fix admin dashboard Chart.js script regression

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -50,7 +50,11 @@
     </main>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <!-- Load the Chart.js UMD bundle with a local fallback so the dashboard works offline
+       and avoids the ESM bundle that triggered "Cannot access 'ct' before initialization"
+       errors in some browsers. -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" crossorigin="anonymous"
+          onerror="this.onerror=null;this.src='/libs/chart-4.5.0.min.js';"></script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the Chart.js UMD bundle on the admin dashboard with a local fallback to avoid the ct initialization error in browsers

## Testing
- npx tsc -p tsconfig.admin.json

------
https://chatgpt.com/codex/tasks/task_e_6900bb51b8c0832891c69a9d008fb3ec