### PR TITLE
Adopt shared ECS for gameplay state replication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,6 +1961,12 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/bitecs": {
+      "version": "0.3.40",
+      "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.3.40.tgz",
+      "integrity": "sha512-wAylY4pNfX8IeIH5phtwt1lUNtHKrkoSNrArI7Ris2Y4nEQWFIVvXdgAuqprEg9bq8Wolmlj0gVfeG6MFmtI2Q==",
+      "license": "MPL-2.0"
+    },
     "node_modules/bn.js": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
@@ -5504,6 +5510,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanksfornothing/shared": "^1.0.0",
+        "bitecs": "^0.3.40",
         "cannon-es": "^0.20.0",
         "colyseus.js": "^0.16.22",
         "three": "^0.180.0"
@@ -5519,6 +5526,7 @@
         "@colyseus/ws-transport": "^0.16.5",
         "@tanksfornothing/shared": "^1.0.0",
         "bcryptjs": "^3.0.2",
+        "bitecs": "^0.3.40",
         "colyseus": "^0.16.5",
         "cookie": "^1.0.2",
         "cookie-parser": "^1.4.7",
@@ -5539,7 +5547,8 @@
       "name": "@tanksfornothing/shared",
       "version": "1.0.0",
       "dependencies": {
-        "@colyseus/schema": "^3.0.65"
+        "@colyseus/schema": "^3.0.65",
+        "bitecs": "^0.3.40"
       },
       "devDependencies": {}
     }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@tanksfornothing/shared": "^1.0.0",
+    "bitecs": "^0.3.40",
     "cannon-es": "^0.20.0",
     "colyseus.js": "^0.16.22",
     "three": "^0.180.0"

--- a/packages/client/src/remote-world.ts
+++ b/packages/client/src/remote-world.ts
@@ -1,0 +1,184 @@
+// remote-world.ts
+// Summary: Client-side helper that mirrors the server ECS component schema so remote player
+//          tanks can be rendered by iterating bitecs worlds instead of ad-hoc maps.
+// Structure: Wraps a shared GameWorld instance and handles metadata-driven mesh creation, runtime
+//            buffer application, and per-frame mesh synchronisation.
+// Usage: Instantiate within the multiplayer bootstrap and forward Colyseus metadata/runtime
+//        updates to keep remote tanks in sync with the authoritative server simulation.
+// ---------------------------------------------------------------------------
+
+import * as THREE from 'three';
+import {
+  applyPlayerRuntimeBuffer,
+  createEntity,
+  createGameWorld,
+  destroyEntity,
+  GameWorld,
+  PlayerMetadataSchema,
+  PlayerRuntimeBufferSchema,
+  TransformComponent,
+  type EnsureEntityForId,
+  type TankSnapshot
+} from '@tanksfornothing/shared';
+
+interface RemoteMeshBundle {
+  mesh: THREE.Object3D;
+  turret: THREE.Object3D;
+  gun: THREE.Object3D | null;
+}
+
+export class RemoteWorldRenderer {
+  private world: GameWorld = createGameWorld();
+  private readonly sessionToServer = new Map<string, number>();
+  private readonly serverToSession = new Map<number, string>();
+  private readonly serverToLocal = new Map<number, number>();
+  private readonly meshes = new Map<number, RemoteMeshBundle>();
+  private readonly ensureEntity: EnsureEntityForId;
+
+  constructor(
+    private readonly scene: THREE.Scene,
+    private readonly createTankMesh: (tank: TankSnapshot) => RemoteMeshBundle,
+    private readonly getLocalSessionId: () => string
+  ) {
+    this.ensureEntity = (serverEntityId) => {
+      const ownerSession = this.serverToSession.get(serverEntityId);
+      if (!ownerSession || ownerSession === this.getLocalSessionId()) {
+        return null;
+      }
+      if (!this.serverToLocal.has(serverEntityId)) {
+        const local = createEntity(this.world);
+        this.serverToLocal.set(serverEntityId, local);
+      }
+      return this.serverToLocal.get(serverEntityId) ?? null;
+    };
+  }
+
+  addOrUpdateMetadata(sessionId: string, schema: PlayerMetadataSchema): void {
+    this.sessionToServer.set(sessionId, schema.entityId);
+    this.serverToSession.set(schema.entityId, sessionId);
+
+    if (sessionId === this.getLocalSessionId()) {
+      return;
+    }
+
+    const existing = this.meshes.get(schema.entityId);
+    if (existing) {
+      return;
+    }
+
+    const bundle = this.createTankMesh({
+      name: schema.tankName,
+      nation: schema.nation,
+      battleRating: schema.battleRating,
+      tankClass: schema.tankClass,
+      armor: schema.armor,
+      turretArmor: schema.turretArmor,
+      cannonCaliber: schema.cannonCaliber,
+      barrelLength: schema.barrelLength,
+      mainCannonFireRate: schema.mainCannonFireRate,
+      crew: schema.crew,
+      engineHp: schema.engineHp,
+      maxSpeed: schema.maxSpeed,
+      maxReverseSpeed: schema.maxReverseSpeed,
+      incline: schema.incline,
+      bodyRotation: schema.bodyRotation,
+      turretRotation: schema.turretRotation,
+      maxTurretIncline: schema.maxTurretIncline,
+      maxTurretDecline: schema.maxTurretDecline,
+      horizontalTraverse: schema.horizontalTraverse,
+      bodyWidth: schema.bodyWidth,
+      bodyLength: schema.bodyLength,
+      bodyHeight: schema.bodyHeight,
+      turretWidth: schema.turretWidth,
+      turretLength: schema.turretLength,
+      turretHeight: schema.turretHeight,
+      turretXPercent: schema.turretXPercent,
+      turretYPercent: schema.turretYPercent
+    });
+    this.scene.add(bundle.mesh);
+    this.meshes.set(schema.entityId, bundle);
+  }
+
+  removeMetadata(sessionId: string): void {
+    const serverEntity = this.sessionToServer.get(sessionId);
+    if (typeof serverEntity === 'number') {
+      this.sessionToServer.delete(sessionId);
+      this.serverToSession.delete(serverEntity);
+      const localEntity = this.serverToLocal.get(serverEntity);
+      if (typeof localEntity === 'number') {
+        destroyEntity(this.world, localEntity);
+        this.serverToLocal.delete(serverEntity);
+      }
+      const bundle = this.meshes.get(serverEntity);
+      if (bundle) {
+        this.disposeMesh(bundle.mesh);
+        this.meshes.delete(serverEntity);
+      }
+    }
+  }
+
+  applyRuntime(runtime: PlayerRuntimeBufferSchema): void {
+    const seen = applyPlayerRuntimeBuffer(this.world, runtime, this.ensureEntity);
+    for (const [serverEntity, localEntity] of [...this.serverToLocal]) {
+      if (!seen.has(serverEntity)) {
+        destroyEntity(this.world, localEntity);
+        this.serverToLocal.delete(serverEntity);
+        const bundle = this.meshes.get(serverEntity);
+        if (bundle) {
+          this.disposeMesh(bundle.mesh);
+          this.meshes.delete(serverEntity);
+        }
+      }
+    }
+  }
+
+  updateMeshes(): void {
+    for (const [serverEntity, bundle] of this.meshes) {
+      const localEntity = this.serverToLocal.get(serverEntity);
+      if (typeof localEntity !== 'number') continue;
+      bundle.mesh.position.set(
+        TransformComponent.x[localEntity] || 0,
+        TransformComponent.y[localEntity] || 0,
+        TransformComponent.z[localEntity] || 0
+      );
+      bundle.mesh.rotation.y = TransformComponent.rot[localEntity] || 0;
+      bundle.turret.rotation.y = TransformComponent.turret[localEntity] || 0;
+      if (bundle.gun) {
+        bundle.gun.rotation.x = TransformComponent.gun[localEntity] || 0;
+      }
+    }
+  }
+
+  clear(): void {
+    for (const bundle of this.meshes.values()) {
+      this.disposeMesh(bundle.mesh);
+    }
+    this.meshes.clear();
+    this.sessionToServer.clear();
+    this.serverToSession.clear();
+    this.serverToLocal.clear();
+    this.world = createGameWorld();
+  }
+
+  getWorld(): GameWorld {
+    return this.world;
+  }
+
+  private disposeMesh(mesh: THREE.Object3D): void {
+    this.scene.remove(mesh);
+    mesh.traverse((obj: THREE.Object3D) => {
+      const meshObj = obj as THREE.Mesh;
+      if (meshObj.geometry) {
+        meshObj.geometry.dispose();
+      }
+      const material = meshObj.material;
+      if (Array.isArray(material)) {
+        material.forEach((m) => {
+          if (m && typeof m.dispose === 'function') m.dispose();
+        });
+      } else if (material && typeof material.dispose === 'function') {
+        material.dispose();
+      }
+    });
+  }
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@colyseus/ws-transport": "^0.16.5",
     "@tanksfornothing/shared": "^1.0.0",
     "bcryptjs": "^3.0.2",
+    "bitecs": "^0.3.40",
     "colyseus": "^0.16.5",
     "cookie": "^1.0.2",
     "cookie-parser": "^1.4.7",

--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -172,7 +172,8 @@ export class ServerWorldController {
     TargetComponent.z[entity] = this.sanitiseNumber(target.z, TargetComponent.z[entity]);
     TargetComponent.rot[entity] = this.normaliseAngle(target.rot, TargetComponent.rot[entity]);
     TargetComponent.turret[entity] = this.normaliseAngle(target.turret, TargetComponent.turret[entity]);
-    TargetComponent.gun[entity] = this.normaliseAngle(target.gun, TargetComponent.gun[entity]);
+    // Preserve negative depression inputs so integratePlayer can clamp against gunDepression correctly.
+    TargetComponent.gun[entity] = this.sanitiseNumber(target.gun, TargetComponent.gun[entity]);
   }
 
   queueFire(sessionId: string, ammoName: string): void {

--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -1,0 +1,548 @@
+// server-world.ts
+// Summary: Authoritative ECS controller used by TanksForNothingRoom to manage player and
+//          projectile entities, run movement/cooldown systems, and serialise snapshots into the
+//          shared Colyseus state.
+// Structure: Encapsulates bitecs world management plus metadata/bookkeeping maps so the room
+//            can remain focused on networking concerns. Exposes high-level methods for spawning
+//            players, applying input targets, handling fire requests, ticking the simulation, and
+//            synchronising Colyseus schema buffers.
+// Usage: Instantiated once per room; TanksForNothingRoom delegates to the instance for all ECS
+//        operations before forwarding resulting events to connected clients.
+// ---------------------------------------------------------------------------
+
+import {
+  addComponent,
+  hasComponent
+} from 'bitecs';
+import {
+  AmmoStateComponent,
+  CooldownComponent,
+  GameWorld,
+  PlayerTagComponent,
+  ProjectileComponent,
+  TankStatsComponent,
+  TargetComponent,
+  TransformComponent,
+  VelocityComponent,
+  HealthComponent,
+  createEntity,
+  createGameWorld,
+  destroyEntity,
+  writePlayerRuntimeBuffer,
+  writeProjectileRuntimeBuffer,
+  type PlayerMetadata,
+  type ProjectileMetadata,
+  type TankSnapshot,
+  cloneAmmoLoadout,
+  PlayerMetadataSchema,
+  TanksForNothingState
+} from '@tanksfornothing/shared';
+
+import type { AmmoDefinition, TankDefinition } from '../types.js';
+
+interface PlayerTargetPayload {
+  x?: number;
+  y?: number;
+  z?: number;
+  rot?: number;
+  turret?: number;
+  gun?: number;
+}
+
+interface FireRequest {
+  ammoName: string;
+}
+
+interface StepResult {
+  explosions: Array<{ id: string; x: number; y: number; z: number }>;
+  damage: Array<{ sessionId: string; health: number; shooter: string | null }>;
+  kills: Array<{ shooter: string | null; victim: string }>;
+}
+
+interface ServerWorldOptions {
+  getAmmo: () => AmmoDefinition[];
+}
+
+const GRAVITY = -9.81;
+const PROJECTILE_LIFETIME = 5;
+
+export class ServerWorldController {
+  readonly world: GameWorld;
+  private readonly playerEntities = new Map<string, number>();
+  private readonly metadata = new Map<string, PlayerMetadata>();
+  private readonly projectileMetadata = new Map<string, ProjectileMetadata>();
+  private readonly fireRequests = new Map<number, FireRequest>();
+  private readonly ammoByName = new Map<string, AmmoDefinition>();
+
+  constructor(private readonly options: ServerWorldOptions) {
+    this.world = createGameWorld();
+    for (const ammo of options.getAmmo()) {
+      this.ammoByName.set(ammo.name, ammo);
+    }
+  }
+
+  refreshAmmoCatalog(): void {
+    this.ammoByName.clear();
+    for (const ammo of this.options.getAmmo()) {
+      this.ammoByName.set(ammo.name, ammo);
+    }
+  }
+
+  addPlayer(
+    sessionId: string,
+    username: string,
+    tank: TankDefinition,
+    loadout: Record<string, number>,
+    ammoRemaining: number
+  ): void {
+    const entity = createEntity(this.world);
+    this.playerEntities.set(sessionId, entity);
+
+    addComponent(this.world, PlayerTagComponent, entity);
+    addComponent(this.world, TransformComponent, entity);
+    addComponent(this.world, TargetComponent, entity);
+    addComponent(this.world, VelocityComponent, entity);
+    addComponent(this.world, HealthComponent, entity);
+    addComponent(this.world, AmmoStateComponent, entity);
+    addComponent(this.world, CooldownComponent, entity);
+    addComponent(this.world, TankStatsComponent, entity);
+
+    TransformComponent.x[entity] = 0;
+    TransformComponent.y[entity] = 0;
+    TransformComponent.z[entity] = 0;
+    TransformComponent.rot[entity] = 0;
+    TransformComponent.turret[entity] = 0;
+    TransformComponent.gun[entity] = 0;
+
+    TargetComponent.x[entity] = 0;
+    TargetComponent.y[entity] = 0;
+    TargetComponent.z[entity] = 0;
+    TargetComponent.rot[entity] = 0;
+    TargetComponent.turret[entity] = 0;
+    TargetComponent.gun[entity] = 0;
+
+    VelocityComponent.vx[entity] = 0;
+    VelocityComponent.vy[entity] = 0;
+    VelocityComponent.vz[entity] = 0;
+
+    HealthComponent.current[entity] = 100;
+    HealthComponent.max[entity] = 100;
+
+    AmmoStateComponent.capacity[entity] = Math.max(0, Math.floor(tank.ammoCapacity ?? 0));
+    AmmoStateComponent.remaining[entity] = Math.max(0, Math.floor(ammoRemaining));
+
+    CooldownComponent.value[entity] = 0;
+
+    TankStatsComponent.maxSpeed[entity] = tank.maxSpeed ?? 10;
+    TankStatsComponent.maxReverseSpeed[entity] = tank.maxReverseSpeed ?? 5;
+    TankStatsComponent.turretRotation[entity] = tank.turretRotation ?? 30;
+    TankStatsComponent.gunDepression[entity] = tank.maxTurretDecline ?? -10;
+    TankStatsComponent.gunElevation[entity] = tank.maxTurretIncline ?? 10;
+    TankStatsComponent.barrelLength[entity] = tank.barrelLength ?? 3;
+    TankStatsComponent.bodyWidth[entity] = tank.bodyWidth ?? 3;
+    TankStatsComponent.bodyLength[entity] = tank.bodyLength ?? 6;
+    TankStatsComponent.bodyHeight[entity] = tank.bodyHeight ?? 2;
+    TankStatsComponent.turretWidth[entity] = tank.turretWidth ?? 2;
+    TankStatsComponent.turretLength[entity] = tank.turretLength ?? 3;
+    TankStatsComponent.turretHeight[entity] = tank.turretHeight ?? 1.5;
+    TankStatsComponent.turretXPercent[entity] = tank.turretXPercent ?? 50;
+    TankStatsComponent.turretYPercent[entity] = tank.turretYPercent ?? 50;
+
+    const metadata = this.toPlayerMetadata(sessionId, username, tank, entity, loadout);
+    metadata.ammoCapacity = AmmoStateComponent.capacity[entity];
+    this.metadata.set(sessionId, metadata);
+    this.recalculateAmmoRemaining(metadata);
+  }
+
+  removePlayer(sessionId: string): void {
+    const entity = this.playerEntities.get(sessionId);
+    if (typeof entity === 'number') {
+      destroyEntity(this.world, entity);
+    }
+    this.playerEntities.delete(sessionId);
+    this.metadata.delete(sessionId);
+  }
+
+  updatePlayerTarget(sessionId: string, target: PlayerTargetPayload): void {
+    const entity = this.playerEntities.get(sessionId);
+    if (typeof entity !== 'number') return;
+
+    TargetComponent.x[entity] = this.sanitiseNumber(target.x, TargetComponent.x[entity]);
+    TargetComponent.y[entity] = this.sanitiseNumber(target.y, TargetComponent.y[entity]);
+    TargetComponent.z[entity] = this.sanitiseNumber(target.z, TargetComponent.z[entity]);
+    TargetComponent.rot[entity] = this.normaliseAngle(target.rot, TargetComponent.rot[entity]);
+    TargetComponent.turret[entity] = this.normaliseAngle(target.turret, TargetComponent.turret[entity]);
+    TargetComponent.gun[entity] = this.normaliseAngle(target.gun, TargetComponent.gun[entity]);
+  }
+
+  queueFire(sessionId: string, ammoName: string): void {
+    const entity = this.playerEntities.get(sessionId);
+    if (typeof entity !== 'number') return;
+    this.fireRequests.set(entity, { ammoName });
+  }
+
+  step(dt: number): StepResult {
+    const explosions: StepResult['explosions'] = [];
+    const damage: StepResult['damage'] = [];
+    const kills: StepResult['kills'] = [];
+
+    for (const [sessionId, meta] of this.metadata) {
+      const entity = meta.entity;
+      if (!hasComponent(this.world, TransformComponent, entity)) continue;
+      this.integratePlayer(entity, dt);
+    }
+
+    for (const [entity, request] of [...this.fireRequests]) {
+      this.processFireRequest(entity, request);
+      this.fireRequests.delete(entity);
+    }
+
+    this.stepProjectiles(dt, explosions, damage, kills);
+
+    return { explosions, damage, kills };
+  }
+
+  synchroniseState(state: TanksForNothingState): void {
+    const knownSessions = new Set(state.playerMetadata.keys());
+    for (const [sessionId, meta] of this.metadata) {
+      let schema = state.playerMetadata.get(sessionId);
+      if (!schema) {
+        schema = new PlayerMetadataSchema();
+        state.playerMetadata.set(sessionId, schema);
+      }
+      schema.entityId = meta.entity;
+      schema.username = meta.username;
+      schema.tankName = meta.tank.name;
+      schema.nation = meta.tank.nation;
+      schema.battleRating = meta.tank.battleRating;
+      schema.tankClass = meta.tank.tankClass;
+      schema.armor = meta.tank.armor;
+      schema.turretArmor = meta.tank.turretArmor;
+      schema.cannonCaliber = meta.tank.cannonCaliber;
+      schema.barrelLength = meta.tank.barrelLength;
+      schema.mainCannonFireRate = meta.tank.mainCannonFireRate;
+      schema.crew = meta.tank.crew;
+      schema.engineHp = meta.tank.engineHp;
+      schema.maxSpeed = meta.tank.maxSpeed;
+      schema.maxReverseSpeed = meta.tank.maxReverseSpeed;
+      schema.incline = meta.tank.incline;
+      schema.bodyRotation = meta.tank.bodyRotation;
+      schema.turretRotation = meta.tank.turretRotation;
+      schema.maxTurretIncline = meta.tank.maxTurretIncline;
+      schema.maxTurretDecline = meta.tank.maxTurretDecline;
+      schema.horizontalTraverse = meta.tank.horizontalTraverse;
+      schema.bodyWidth = meta.tank.bodyWidth;
+      schema.bodyLength = meta.tank.bodyLength;
+      schema.bodyHeight = meta.tank.bodyHeight;
+      schema.turretWidth = meta.tank.turretWidth;
+      schema.turretLength = meta.tank.turretLength;
+      schema.turretHeight = meta.tank.turretHeight;
+      schema.turretXPercent = meta.tank.turretXPercent;
+      schema.turretYPercent = meta.tank.turretYPercent;
+      schema.ammoCapacity = meta.ammoCapacity;
+
+      const loadoutSchema = schema.ammoLoadout;
+      for (const key of [...loadoutSchema.keys()]) {
+        if (!(key in meta.ammoLoadout)) {
+          loadoutSchema.delete(key);
+        }
+      }
+      for (const [ammo, count] of Object.entries(meta.ammoLoadout)) {
+        loadoutSchema.set(ammo, count);
+      }
+
+      knownSessions.delete(sessionId);
+    }
+
+    for (const sessionId of knownSessions) {
+      state.playerMetadata.delete(sessionId);
+    }
+
+    writePlayerRuntimeBuffer(this.world, this.metadata.values(), state.playerRuntime);
+    writeProjectileRuntimeBuffer(this.world, this.projectileMetadata.values(), state.projectileRuntime);
+    state.tick += 1;
+  }
+
+  getMetadataForSession(sessionId: string): PlayerMetadata | undefined {
+    return this.metadata.get(sessionId);
+  }
+
+  getMetadataForEntity(entity: number): PlayerMetadata | undefined {
+    for (const meta of this.metadata.values()) {
+      if (meta.entity === entity) return meta;
+    }
+    return undefined;
+  }
+
+  removeExpiredProjectiles(): void {
+    for (const [id, meta] of this.projectileMetadata) {
+      if (!hasComponent(this.world, ProjectileComponent, meta.entity)) {
+        this.projectileMetadata.delete(id);
+      }
+    }
+  }
+
+  private sanitiseNumber(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  }
+
+  private normaliseAngle(value: unknown, fallback: number): number {
+    const numeric = this.sanitiseNumber(value, fallback);
+    if (!Number.isFinite(numeric)) return fallback;
+    const twoPi = Math.PI * 2;
+    return ((numeric % twoPi) + twoPi) % twoPi;
+  }
+
+  private toPlayerMetadata(
+    sessionId: string,
+    username: string,
+    tank: TankDefinition,
+    entity: number,
+    loadout: Record<string, number>
+  ): PlayerMetadata {
+    const tankSnapshot: TankSnapshot = {
+      name: tank.name,
+      nation: tank.nation,
+      battleRating: tank.br,
+      tankClass: tank.class,
+      armor: tank.armor ?? 0,
+      turretArmor: tank.turretArmor ?? 0,
+      cannonCaliber: tank.cannonCaliber ?? 0,
+      barrelLength: tank.barrelLength ?? 0,
+      mainCannonFireRate: tank.mainCannonFireRate ?? 0,
+      crew: tank.crew ?? 0,
+      engineHp: tank.engineHp ?? 0,
+      maxSpeed: tank.maxSpeed ?? 0,
+      maxReverseSpeed: tank.maxReverseSpeed ?? 0,
+      incline: tank.incline ?? 0,
+      bodyRotation: tank.bodyRotation ?? 0,
+      turretRotation: tank.turretRotation ?? 0,
+      maxTurretIncline: tank.maxTurretIncline ?? 0,
+      maxTurretDecline: tank.maxTurretDecline ?? 0,
+      horizontalTraverse: tank.horizontalTraverse ?? 0,
+      bodyWidth: tank.bodyWidth ?? 0,
+      bodyLength: tank.bodyLength ?? 0,
+      bodyHeight: tank.bodyHeight ?? 0,
+      turretWidth: tank.turretWidth ?? 0,
+      turretLength: tank.turretLength ?? 0,
+      turretHeight: tank.turretHeight ?? 0,
+      turretXPercent: tank.turretXPercent ?? 50,
+      turretYPercent: tank.turretYPercent ?? 50
+    };
+
+    return {
+      entity,
+      sessionId,
+      username,
+      tank: tankSnapshot,
+      ammoLoadout: cloneAmmoLoadout(loadout),
+      ammoCapacity: tank.ammoCapacity ?? 0
+    };
+  }
+
+  private recalculateAmmoRemaining(meta: PlayerMetadata): number {
+    const entity = meta.entity;
+    const total = Object.values(meta.ammoLoadout).reduce((sum, count) => sum + Math.max(0, count), 0);
+    AmmoStateComponent.remaining[entity] = Math.max(0, Math.min(total, AmmoStateComponent.capacity[entity] ?? total));
+    return AmmoStateComponent.remaining[entity];
+  }
+
+  private integratePlayer(entity: number, dt: number): void {
+    const targetX = TargetComponent.x[entity];
+    const targetY = TargetComponent.y[entity];
+    const targetZ = TargetComponent.z[entity];
+    const targetRot = TargetComponent.rot[entity];
+    const targetTurret = TargetComponent.turret[entity];
+    const targetGun = TargetComponent.gun[entity];
+
+    const maxSpeed = TankStatsComponent.maxSpeed[entity] || 10;
+    const maxReverse = TankStatsComponent.maxReverseSpeed[entity] || 5;
+    const maxTurretRate = TankStatsComponent.turretRotation[entity] || 30;
+    const gunElevation = TankStatsComponent.gunElevation[entity] || 10;
+    const gunDepression = TankStatsComponent.gunDepression[entity] || -10;
+
+    const dx = targetX - TransformComponent.x[entity];
+    const dy = targetY - TransformComponent.y[entity];
+    const dz = targetZ - TransformComponent.z[entity];
+
+    const desiredSpeed = Math.sqrt(dx * dx + dz * dz) / Math.max(dt, 0.0001);
+    const clampedSpeed = Math.min(desiredSpeed, dx >= 0 ? maxSpeed : maxReverse);
+    const speedRatio = desiredSpeed > 0 ? clampedSpeed / desiredSpeed : 0;
+
+    TransformComponent.x[entity] += dx * speedRatio * dt;
+    TransformComponent.y[entity] += dy * Math.min(1, dt * 10);
+    TransformComponent.z[entity] += dz * speedRatio * dt;
+
+    VelocityComponent.vx[entity] = dx * speedRatio;
+    VelocityComponent.vy[entity] = dy * Math.min(1, dt * 10);
+    VelocityComponent.vz[entity] = dz * speedRatio;
+
+    const rotDelta = this.shortestAngleDelta(TransformComponent.rot[entity], targetRot);
+    const maxRotStep = (maxSpeed > 0 ? maxSpeed : 30) * dt * 0.5;
+    TransformComponent.rot[entity] = this.wrapAngle(TransformComponent.rot[entity] + this.clamp(rotDelta, -maxRotStep, maxRotStep));
+
+    const turretDelta = this.shortestAngleDelta(TransformComponent.turret[entity], targetTurret);
+    const maxTurretStep = (maxTurretRate || 30) * dt * (Math.PI / 180);
+    TransformComponent.turret[entity] = this.wrapAngle(TransformComponent.turret[entity] + this.clamp(turretDelta, -maxTurretStep, maxTurretStep));
+
+    const gunDelta = targetGun - TransformComponent.gun[entity];
+    const clampedGunTarget = this.clamp(targetGun, gunDepression * (Math.PI / 180), gunElevation * (Math.PI / 180));
+    const gunStep = this.clamp(clampedGunTarget - TransformComponent.gun[entity], -maxTurretStep, maxTurretStep);
+    TransformComponent.gun[entity] += gunStep;
+
+    if (CooldownComponent.value[entity] > 0) {
+      CooldownComponent.value[entity] = Math.max(0, CooldownComponent.value[entity] - dt);
+    }
+  }
+
+  private processFireRequest(entity: number, request: FireRequest): boolean {
+    if (!hasComponent(this.world, TransformComponent, entity)) return false;
+    if (CooldownComponent.value[entity] > 0) return false;
+    const ammo = this.ammoByName.get(request.ammoName);
+    if (!ammo) return false;
+
+    const meta = this.getMetadataForEntity(entity);
+    if (!meta) return false;
+
+    const current = meta.ammoLoadout[ammo.name] ?? 0;
+    if (current <= 0) return false;
+
+    const projectileId = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2)}`;
+    const projectileEntity = createEntity(this.world);
+    addComponent(this.world, ProjectileComponent, projectileEntity);
+    addComponent(this.world, TransformComponent, projectileEntity);
+
+    const { muzzleX, muzzleY, muzzleZ, vx, vy, vz } = this.computeMuzzle(meta, ammo, entity);
+    TransformComponent.x[projectileEntity] = muzzleX;
+    TransformComponent.y[projectileEntity] = muzzleY;
+    TransformComponent.z[projectileEntity] = muzzleZ;
+    ProjectileComponent.vx[projectileEntity] = vx;
+    ProjectileComponent.vy[projectileEntity] = vy;
+    ProjectileComponent.vz[projectileEntity] = vz;
+    ProjectileComponent.life[projectileEntity] = PROJECTILE_LIFETIME;
+    ProjectileComponent.shooter[projectileEntity] = entity;
+
+    meta.ammoLoadout[ammo.name] = current - 1;
+    this.recalculateAmmoRemaining(meta);
+
+    CooldownComponent.value[entity] = this.computeCooldown(meta);
+
+    this.projectileMetadata.set(projectileId, {
+      entity: projectileEntity,
+      id: projectileId,
+      ammoName: ammo.name,
+      shooterSessionId: meta.sessionId,
+      damage: ammo.damage ?? ammo.penetration ?? 10,
+      penetration: ammo.penetration ?? ammo.pen0 ?? 0,
+      explosion: ammo.explosion ?? ammo.explosionRadius ?? 0
+    });
+
+    return true;
+  }
+
+  private stepProjectiles(
+    dt: number,
+    explosions: StepResult['explosions'],
+    damage: StepResult['damage'],
+    kills: StepResult['kills']
+  ): void {
+    for (const [id, meta] of [...this.projectileMetadata]) {
+      const entity = meta.entity;
+      if (!hasComponent(this.world, ProjectileComponent, entity) || !hasComponent(this.world, TransformComponent, entity)) {
+        this.projectileMetadata.delete(id);
+        continue;
+      }
+
+      ProjectileComponent.vy[entity] += GRAVITY * dt;
+      TransformComponent.x[entity] += ProjectileComponent.vx[entity] * dt;
+      TransformComponent.y[entity] += ProjectileComponent.vy[entity] * dt;
+      TransformComponent.z[entity] += ProjectileComponent.vz[entity] * dt;
+      ProjectileComponent.life[entity] -= dt;
+
+      if (TransformComponent.y[entity] <= 0 || ProjectileComponent.life[entity] <= 0) {
+        explosions.push({ id, x: TransformComponent.x[entity], y: TransformComponent.y[entity], z: TransformComponent.z[entity] });
+        destroyEntity(this.world, entity);
+        this.projectileMetadata.delete(id);
+        continue;
+      }
+
+      for (const [sessionId, playerMeta] of this.metadata) {
+        if (playerMeta.entity === ProjectileComponent.shooter[entity]) continue;
+        const targetEntity = playerMeta.entity;
+        if (!hasComponent(this.world, TransformComponent, targetEntity)) continue;
+        const dx = TransformComponent.x[targetEntity] - TransformComponent.x[entity];
+        const dy = TransformComponent.y[targetEntity] - TransformComponent.y[entity];
+        const dz = TransformComponent.z[targetEntity] - TransformComponent.z[entity];
+        if (Math.sqrt(dx * dx + dy * dy + dz * dz) < 2) {
+          const remainingHealth = this.applyDamage(targetEntity, meta);
+          damage.push({ sessionId, health: remainingHealth, shooter: meta.shooterSessionId });
+          explosions.push({ id, x: TransformComponent.x[entity], y: TransformComponent.y[entity], z: TransformComponent.z[entity] });
+          destroyEntity(this.world, entity);
+          this.projectileMetadata.delete(id);
+          if (remainingHealth <= 0) {
+            kills.push({ shooter: meta.shooterSessionId, victim: sessionId });
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  private applyDamage(targetEntity: number, projectile: ProjectileMetadata): number {
+    const healthBefore = HealthComponent.current[targetEntity] ?? 100;
+    const armor = this.getMetadataForEntity(targetEntity)?.tank.armor ?? 0;
+    const penetrationBonus = projectile.penetration > armor ? projectile.damage : projectile.damage / 2;
+    const totalDamage = Math.max(5, penetrationBonus + projectile.explosion);
+    const nextHealth = Math.max(0, healthBefore - totalDamage);
+    HealthComponent.current[targetEntity] = nextHealth;
+    return nextHealth;
+  }
+
+  private computeCooldown(meta: PlayerMetadata): number {
+    const fireRate = meta.tank.mainCannonFireRate ?? 0;
+    if (fireRate <= 0) return 1;
+    return Math.max(0.1, 60 / fireRate);
+  }
+
+  private computeMuzzle(meta: PlayerMetadata, ammo: AmmoDefinition, entity: number): {
+    muzzleX: number;
+    muzzleY: number;
+    muzzleZ: number;
+    vx: number;
+    vy: number;
+    vz: number;
+  } {
+    const yaw = (TransformComponent.rot[entity] || 0) + (TransformComponent.turret[entity] || 0);
+    const pitch = TransformComponent.gun[entity] || 0;
+    const cosPitch = Math.cos(pitch);
+    const sinYaw = Math.sin(yaw);
+    const cosYaw = Math.cos(yaw);
+    const speed = ammo.speed ?? 200;
+    const barrelLen = meta.tank.barrelLength || TankStatsComponent.barrelLength[entity] || 3;
+    const turretYOffset = (meta.tank.turretYPercent ?? 50) / 100 - 0.5;
+    const turretXOffset = 0.5 - (meta.tank.turretXPercent ?? 50) / 100;
+    const muzzleX = TransformComponent.x[entity] + turretYOffset * meta.tank.bodyWidth - sinYaw * cosPitch * barrelLen;
+    const muzzleY = TransformComponent.y[entity] + meta.tank.bodyHeight / 2 + Math.sin(pitch) * barrelLen;
+    const muzzleZ = TransformComponent.z[entity] + turretXOffset * meta.tank.bodyLength - cosYaw * cosPitch * barrelLen;
+    const vx = -sinYaw * cosPitch * speed;
+    const vy = Math.sin(pitch) * speed;
+    const vz = -cosYaw * cosPitch * speed;
+    return { muzzleX, muzzleY, muzzleZ, vx, vy, vz };
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  private wrapAngle(value: number): number {
+    const twoPi = Math.PI * 2;
+    return ((value % twoPi) + twoPi) % twoPi;
+  }
+
+  private shortestAngleDelta(current: number, target: number): number {
+    const delta = this.wrapAngle(target) - this.wrapAngle(current);
+    if (delta > Math.PI) return delta - Math.PI * 2;
+    if (delta < -Math.PI) return delta + Math.PI * 2;
+    return delta;
+  }
+}

--- a/packages/server/src/game/tanks-room.ts
+++ b/packages/server/src/game/tanks-room.ts
@@ -12,17 +12,15 @@
 
 import type { AuthContext, Client } from 'colyseus';
 import { Room } from 'colyseus';
-import { MapSchema } from '@colyseus/schema';
 import {
   GAME_COMMAND,
   GAME_EVENT,
   TanksForNothingState,
-  PlayerStateSchema,
-  ProjectileStateSchema,
   type AmmoLoadout
 } from '@tanksfornothing/shared';
 
 import type { AmmoDefinition, TankDefinition, TerrainPayload } from '../types.js';
+import { ServerWorldController } from './server-world.js';
 
 interface TanksRoomDependencies {
   authenticate: (context: AuthContext) => { username: string } | { error: string };
@@ -41,29 +39,23 @@ interface JoinOptions {
   loadout?: AmmoLoadout;
 }
 
-interface PlayerRuntimeState {
-  username: string;
-  tank: TankDefinition;
-  lastFire: number;
-}
-
-const GRAVITY = -9.81;
-
 export class TanksForNothingRoom extends Room<TanksForNothingState> {
   private static readonly activeRooms = new Set<TanksForNothingRoom>();
 
   private dependencies!: TanksRoomDependencies;
   private baseBR: number | null = null;
-  private readonly runtime = new Map<string, PlayerRuntimeState>();
-  private readonly projectileLife = new Map<string, number>();
+  private world!: ServerWorldController;
 
   onCreate(options: { dependencies: TanksRoomDependencies }): void {
     this.dependencies = options.dependencies;
+    this.world = new ServerWorldController({
+      getAmmo: () => this.dependencies.getAmmo()
+    });
     this.setState(new TanksForNothingState());
     const terrain = this.dependencies.getTerrain();
     this.state.terrainName = terrain.name;
     this.state.terrainRevision = Date.now();
-    this.clock.setInterval(() => this.stepProjectiles(0.05), 50);
+    this.clock.setInterval(() => this.stepSimulation(0.05), 50);
     TanksForNothingRoom.activeRooms.add(this);
     this.onMessage(GAME_COMMAND.PlayerUpdate, (client, message) => {
       this.handlePlayerUpdate(client, message);
@@ -114,6 +106,7 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
   onJoin(client: Client, _options: JoinOptions): void {
     const auth = this.getClientAuth(client);
     this.dependencies.recordGameStart(auth.username);
+    this.world.refreshAmmoCatalog();
     this.spawnPlayer(client);
     client.send(GAME_EVENT.TanksCatalog, this.dependencies.getTanks());
     client.send(GAME_EVENT.AmmoCatalog, this.dependencies.getAmmo());
@@ -121,9 +114,9 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
   }
 
   onLeave(client: Client, _consented: boolean): void {
-    this.state.players.delete(client.sessionId);
-    this.runtime.delete(client.sessionId);
-    if (this.state.players.size === 0) {
+    this.world.removePlayer(client.sessionId);
+    this.world.synchroniseState(this.state);
+    if (this.state.playerMetadata.size === 0) {
       this.baseBR = null;
     }
   }
@@ -135,13 +128,14 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
   }
 
   private restartWithTerrain(payload: TerrainPayload): void {
-    this.state.players.clear();
-    this.state.projectiles.clear();
-    this.runtime.clear();
-    this.projectileLife.clear();
+    this.world = new ServerWorldController({
+      getAmmo: () => this.dependencies.getAmmo()
+    });
+    this.world.synchroniseState(this.state);
     this.baseBR = null;
     this.state.terrainName = payload.name;
     this.state.terrainRevision = Date.now();
+    this.state.tick = 0;
     this.broadcast(GAME_EVENT.Restart, true);
     this.broadcast(GAME_EVENT.TerrainDefinition, payload);
   }
@@ -156,194 +150,54 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
 
   private spawnPlayer(client: Client): void {
     const auth = this.getClientAuth(client);
-    const tank = auth.tank;
-    const playerState = new PlayerStateSchema();
-    playerState.username = auth.username;
-    playerState.tankName = tank.name;
-    playerState.nation = tank.nation;
-    playerState.battleRating = tank.br;
-    playerState.tankClass = tank.class;
-    playerState.armor = tank.armor ?? 0;
-    playerState.turretArmor = tank.turretArmor ?? 0;
-    playerState.cannonCaliber = tank.cannonCaliber ?? 0;
-    playerState.barrelLength = tank.barrelLength ?? 0;
-    playerState.mainCannonFireRate = tank.mainCannonFireRate ?? 0;
-    playerState.crew = tank.crew ?? 0;
-    playerState.engineHp = tank.engineHp ?? 0;
-    playerState.maxSpeed = tank.maxSpeed ?? 0;
-    playerState.maxReverseSpeed = tank.maxReverseSpeed ?? 0;
-    playerState.incline = tank.incline ?? 0;
-    playerState.bodyRotation = tank.bodyRotation ?? 0;
-    playerState.turretRotation = tank.turretRotation ?? 0;
-    playerState.maxTurretIncline = tank.maxTurretIncline ?? 0;
-    playerState.maxTurretDecline = tank.maxTurretDecline ?? 0;
-    playerState.horizontalTraverse = tank.horizontalTraverse ?? 0;
-    playerState.bodyWidth = tank.bodyWidth ?? 0;
-    playerState.bodyLength = tank.bodyLength ?? 0;
-    playerState.bodyHeight = tank.bodyHeight ?? 0;
-    playerState.turretWidth = tank.turretWidth ?? 0;
-    playerState.turretLength = tank.turretLength ?? 0;
-    playerState.turretHeight = tank.turretHeight ?? 0;
-    playerState.turretXPercent = tank.turretXPercent ?? 0;
-    playerState.turretYPercent = tank.turretYPercent ?? 0;
-    playerState.x = 0;
-    playerState.y = 0;
-    playerState.z = 0;
-    playerState.rot = 0;
-    playerState.turret = 0;
-    playerState.gun = 0;
-    playerState.health = 100;
-    playerState.ammoLoadout = new MapSchema<number>();
-    for (const [name, count] of Object.entries(auth.loadout)) {
-      playerState.ammoLoadout.set(name, count);
-    }
-    playerState.ammoRemaining = auth.ammoRemaining;
-    this.state.players.set(client.sessionId, playerState);
-    this.runtime.set(client.sessionId, {
-      username: auth.username,
-      tank,
-      lastFire: 0
-    });
+    this.world.addPlayer(client.sessionId, auth.username, auth.tank, auth.loadout, auth.ammoRemaining);
+    this.world.synchroniseState(this.state);
   }
 
   private handlePlayerUpdate(client: Client, payload: unknown): void {
-    let playerState = this.state.players.get(client.sessionId);
-    if (!playerState) {
-      this.spawnPlayer(client);
-      playerState = this.state.players.get(client.sessionId);
-      if (!playerState) return;
-    }
     if (!payload || typeof payload !== 'object') return;
-    const next = payload as Partial<Record<keyof PlayerStateSchema, unknown>>;
-    playerState.x = this.toNumber(next.x, playerState.x);
-    playerState.y = this.toNumber(next.y, playerState.y);
-    playerState.z = this.toNumber(next.z, playerState.z);
-    playerState.rot = this.toNumber(next.rot, playerState.rot);
-    playerState.turret = this.toNumber(next.turret, playerState.turret);
-    playerState.gun = this.toNumber(next.gun, playerState.gun);
-    if (typeof next.health === 'number' && Number.isFinite(next.health)) {
-      playerState.health = Math.max(0, Math.min(100, next.health));
-    }
+    const next = payload as Record<string, unknown>;
+    this.world.updatePlayerTarget(client.sessionId, {
+      x: this.toOptionalNumber(next.x),
+      y: this.toOptionalNumber(next.y),
+      z: this.toOptionalNumber(next.z),
+      rot: this.toOptionalNumber(next.rot),
+      turret: this.toOptionalNumber(next.turret),
+      gun: this.toOptionalNumber(next.gun)
+    });
   }
 
   private handlePlayerFire(client: Client, payload: unknown): void {
     const ammoName = typeof payload === 'string' ? payload : undefined;
     if (!ammoName) return;
-    const playerState = this.state.players.get(client.sessionId);
-    const runtime = this.runtime.get(client.sessionId);
-    if (!playerState || !runtime) return;
-    const now = Date.now();
-    const fireDelay = runtime.tank.mainCannonFireRate > 0 ? 60000 / runtime.tank.mainCannonFireRate : 0;
-    if (fireDelay > 0 && now - runtime.lastFire < fireDelay) return;
-    const currentAmmo = playerState.ammoLoadout.get(ammoName) ?? 0;
-    if (currentAmmo <= 0 || playerState.ammoRemaining <= 0) return;
-    const ammoDef = this.dependencies.getAmmo().find((a) => a.name === ammoName);
-    if (!ammoDef) return;
-
-    runtime.lastFire = now;
-    playerState.ammoLoadout.set(ammoName, currentAmmo - 1);
-    playerState.ammoRemaining = Math.max(0, playerState.ammoRemaining - 1);
-
-    const yaw = (playerState.rot || 0) + (playerState.turret || 0);
-    const pitch = playerState.gun || 0;
-    const cosPitch = Math.cos(pitch);
-    const sinYaw = Math.sin(yaw);
-    const cosYaw = Math.cos(yaw);
-    const speed = ammoDef.speed ?? 200;
-    const barrelLen = playerState.barrelLength ?? runtime.tank.barrelLength ?? 3;
-    const turretYOffset = (playerState.turretYPercent ?? 50) / 100 - 0.5;
-    const turretXOffset = 0.5 - (playerState.turretXPercent ?? 50) / 100;
-    const muzzleX = playerState.x + turretYOffset * playerState.bodyWidth - sinYaw * cosPitch * barrelLen;
-    const muzzleY = playerState.y + 1 + Math.sin(pitch) * barrelLen;
-    const muzzleZ = playerState.z + turretXOffset * playerState.bodyLength - cosYaw * cosPitch * barrelLen;
-
-    const projectile = new ProjectileStateSchema();
-    const id = `${now}-${Math.random().toString(16).slice(2)}`;
-    projectile.id = id;
-    projectile.x = muzzleX;
-    projectile.y = muzzleY;
-    projectile.z = muzzleZ;
-    projectile.vx = -sinYaw * cosPitch * speed;
-    projectile.vy = Math.sin(pitch) * speed;
-    projectile.vz = -cosYaw * cosPitch * speed;
-    projectile.ammo = ammoDef.name;
-    projectile.shooter = client.sessionId;
-
-    this.state.projectiles.set(id, projectile);
-    this.projectileLife.set(id, 5);
-    console.debug('Projectile fired', projectile);
+    this.world.queueFire(client.sessionId, ammoName);
   }
 
-  private stepProjectiles(dt: number): void {
+  private stepSimulation(dt: number): void {
     try {
-      for (const [id, projectile] of this.state.projectiles) {
-        projectile.vy += GRAVITY * dt;
-        projectile.x += projectile.vx * dt;
-        projectile.y += projectile.vy * dt;
-        projectile.z += projectile.vz * dt;
-        if (projectile.y <= 0) {
-          this.destroyProjectile(id, projectile);
-          continue;
-        }
-        let exploded = false;
-        for (const [sessionId, player] of this.state.players) {
-          if (sessionId === projectile.shooter) continue;
-          const dx = player.x - projectile.x;
-          const dy = player.y - projectile.y;
-          const dz = player.z - projectile.z;
-          if (Math.sqrt(dx * dx + dy * dy + dz * dz) < 2) {
-            this.applyDamage(sessionId, projectile);
-            this.destroyProjectile(id, projectile);
-            exploded = true;
-            break;
+      const result = this.world.step(dt);
+      for (const explosion of result.explosions) {
+        this.broadcast(GAME_EVENT.ProjectileExploded, explosion);
+      }
+      for (const hit of result.damage) {
+        this.broadcast(GAME_EVENT.TankDamaged, { id: hit.sessionId, health: hit.health });
+      }
+      if (result.kills.length > 0) {
+        for (const entry of result.kills) {
+          const shooterMeta = entry.shooter ? this.world.getMetadataForSession(entry.shooter) : undefined;
+          const victimMeta = this.world.getMetadataForSession(entry.victim);
+          if (shooterMeta) {
+            this.dependencies.recordKill(shooterMeta.username);
+          }
+          if (victimMeta) {
+            this.dependencies.recordDeath(victimMeta.username);
           }
         }
-        if (exploded) continue;
-        const life = (this.projectileLife.get(id) ?? 0) - dt;
-        if (life <= 0) {
-          this.destroyProjectile(id, projectile);
-        } else {
-          this.projectileLife.set(id, life);
-        }
+        void this.dependencies.persistUsers();
       }
+      this.world.synchroniseState(this.state);
     } catch (error) {
-      console.error('Projectile simulation error', error);
-    }
-  }
-
-  private destroyProjectile(id: string, projectile: ProjectileStateSchema): void {
-    this.state.projectiles.delete(id);
-    this.projectileLife.delete(id);
-    this.broadcast(GAME_EVENT.ProjectileExploded, {
-      id,
-      x: projectile.x,
-      y: projectile.y,
-      z: projectile.z
-    });
-  }
-
-  private applyDamage(sessionId: string, projectile: ProjectileStateSchema): void {
-    const player = this.state.players.get(sessionId);
-    if (!player) return;
-    const ammoDef = this.dependencies.getAmmo().find((a) => a.name === projectile.ammo);
-    const damage = ammoDef?.damage ?? ammoDef?.armorPen ?? 10;
-    const penetration = ammoDef?.penetration ?? ammoDef?.pen0 ?? 0;
-    const explosion = ammoDef?.explosion ?? ammoDef?.explosionRadius ?? 0;
-    const armor = player.armor || 0;
-    let total = penetration > armor ? damage : damage / 2;
-    total += explosion;
-    player.health = Math.max(0, player.health - total);
-    this.broadcast(GAME_EVENT.TankDamaged, { id: sessionId, health: player.health });
-    if (player.health <= 0) {
-      const shooterRuntime = this.runtime.get(projectile.shooter);
-      const victimRuntime = this.runtime.get(sessionId);
-      if (shooterRuntime) {
-        this.dependencies.recordKill(shooterRuntime.username);
-      }
-      if (victimRuntime) {
-        this.dependencies.recordDeath(victimRuntime.username);
-      }
-      void this.dependencies.persistUsers();
+      console.error('ECS simulation error', error);
     }
   }
 
@@ -372,9 +226,8 @@ export class TanksForNothingRoom extends Room<TanksForNothingState> {
     return sanitized;
   }
 
-  private toNumber(value: unknown, fallback: number): number {
-    const num = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-    return num;
+  private toOptionalNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   }
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,8 @@
     "test": "echo \"Shared package has no runtime tests yet\""
   },
   "dependencies": {
-    "@colyseus/schema": "^3.0.65"
+    "@colyseus/schema": "^3.0.65",
+    "bitecs": "^0.3.40"
   },
   "devDependencies": {}
 }

--- a/packages/shared/src/ecs/components.ts
+++ b/packages/shared/src/ecs/components.ts
@@ -1,0 +1,148 @@
+// components.ts
+// Summary: Canonical bitecs component declarations shared across server and client worlds
+//          to ensure gameplay and rendering systems operate over identical memory layouts.
+// Structure: Exports strongly typed component factories plus helpers for world management so
+//            simulation systems on the server and renderer adapters on the client can remain
+//            decoupled yet interoperable.
+// Usage: import { TransformComponent, createGameWorld } from '@tanksfornothing/shared/ecs';
+// ---------------------------------------------------------------------------
+
+import {
+  IWorld,
+  addEntity,
+  createWorld,
+  defineComponent,
+  hasComponent,
+  removeEntity,
+  Types
+} from 'bitecs';
+
+/**
+ * TransformComponent stores the current world position/orientation for both player tanks
+ * and transient projectile entities.
+ */
+export const TransformComponent = defineComponent({
+  x: Types.f32,
+  y: Types.f32,
+  z: Types.f32,
+  rot: Types.f32,
+  turret: Types.f32,
+  gun: Types.f32
+});
+
+/**
+ * TargetComponent encodes the latest desired transform as communicated by player input so the
+ * authoritative movement system can apply acceleration limits and smoothing.
+ */
+export const TargetComponent = defineComponent({
+  x: Types.f32,
+  y: Types.f32,
+  z: Types.f32,
+  rot: Types.f32,
+  turret: Types.f32,
+  gun: Types.f32
+});
+
+/**
+ * VelocityComponent captures the last computed linear velocity vector. It allows both the
+ * physics integrator and the network serializer to expose consistent momentum data.
+ */
+export const VelocityComponent = defineComponent({
+  vx: Types.f32,
+  vy: Types.f32,
+  vz: Types.f32
+});
+
+/**
+ * HealthComponent keeps the current and maximum hit points for tanks so damage systems can
+ * clamp values while keeping enough context for HUD updates client-side.
+ */
+export const HealthComponent = defineComponent({
+  current: Types.f32,
+  max: Types.f32
+});
+
+/**
+ * AmmoStateComponent records bulk ammo statistics (capacity and remaining rounds). Fine-grained
+ * per-ammo bookkeeping is handled via metadata maps to avoid sparse component layouts.
+ */
+export const AmmoStateComponent = defineComponent({
+  capacity: Types.ui16,
+  remaining: Types.ui16
+});
+
+/**
+ * CooldownComponent tracks the remaining time until the main cannon may fire again.
+ */
+export const CooldownComponent = defineComponent({
+  value: Types.f32
+});
+
+/**
+ * TankStatsComponent stores frequently accessed numeric characteristics of a tank. Keeping
+ * these values in component memory enables systems to operate without chasing metadata maps
+ * for critical movement limits.
+ */
+export const TankStatsComponent = defineComponent({
+  maxSpeed: Types.f32,
+  maxReverseSpeed: Types.f32,
+  turretRotation: Types.f32,
+  gunDepression: Types.f32,
+  gunElevation: Types.f32,
+  barrelLength: Types.f32,
+  bodyWidth: Types.f32,
+  bodyLength: Types.f32,
+  bodyHeight: Types.f32,
+  turretWidth: Types.f32,
+  turretLength: Types.f32,
+  turretHeight: Types.f32,
+  turretXPercent: Types.f32,
+  turretYPercent: Types.f32
+});
+
+/**
+ * ProjectileComponent identifies projectile entities and stores their inertial state.
+ */
+export const ProjectileComponent = defineComponent({
+  vx: Types.f32,
+  vy: Types.f32,
+  vz: Types.f32,
+  life: Types.f32,
+  shooter: Types.ui32
+});
+
+/**
+ * Tag component attached to player-controlled tank entities so queries can distinguish them
+ * from projectiles and other helper entities without maintaining a separate lookup structure.
+ */
+export const PlayerTagComponent = defineComponent();
+
+/**
+ * Factory for a shared world instance. Keeping this helper in the shared package lets both
+ * server and client initialise worlds without duplicating configuration boilerplate.
+ */
+export function createGameWorld(): IWorld {
+  return createWorld();
+}
+
+/**
+ * Utility to provision a new entity identifier within a world.
+ */
+export function createEntity(world: IWorld): number {
+  return addEntity(world);
+}
+
+/**
+ * Utility to destroy an entity and clear all of its components safely.
+ */
+export function destroyEntity(world: IWorld, entity: number): void {
+  if (hasComponent(world, TransformComponent, entity)) {
+    // Remove transform first to avoid stale references when debugging dumps read component
+    // arrays. We then fall through to removeEntity which clears every other component slot.
+    removeEntity(world, entity);
+    return;
+  }
+  removeEntity(world, entity);
+}
+
+export type GameWorld = IWorld;

--- a/packages/shared/src/ecs/metadata.ts
+++ b/packages/shared/src/ecs/metadata.ts
@@ -1,0 +1,79 @@
+// metadata.ts
+// Summary: Shared metadata helpers describing non-component state that both the server and
+//          client require when translating Colyseus payloads into ECS entities.
+// Structure: Declares serialisable interfaces for tank blueprints, player runtime descriptors,
+//            and projectile bookkeeping alongside convenience helpers for ammo accounting.
+// Usage: import type { PlayerMetadata } from '@tanksfornothing/shared/ecs';
+// ---------------------------------------------------------------------------
+
+import type { AmmoLoadout } from '../schema.js';
+
+/**
+ * TankSnapshot captures the static, mostly geometric properties of a tank. The structure mirrors
+ * the values required to build meshes on the client and to calculate muzzle offsets server-side.
+ */
+export interface TankSnapshot {
+  name: string;
+  nation: string;
+  battleRating: number;
+  tankClass: string;
+  armor: number;
+  turretArmor: number;
+  cannonCaliber: number;
+  barrelLength: number;
+  mainCannonFireRate: number;
+  crew: number;
+  engineHp: number;
+  maxSpeed: number;
+  maxReverseSpeed: number;
+  incline: number;
+  bodyRotation: number;
+  turretRotation: number;
+  maxTurretIncline: number;
+  maxTurretDecline: number;
+  horizontalTraverse: number;
+  bodyWidth: number;
+  bodyLength: number;
+  bodyHeight: number;
+  turretWidth: number;
+  turretLength: number;
+  turretHeight: number;
+  turretXPercent: number;
+  turretYPercent: number;
+}
+
+/**
+ * PlayerMetadata captures strings and high-level numbers that would bloat component arrays. It is
+ * keyed by Colyseus sessionId when replicated through the schema.
+ */
+export interface PlayerMetadata {
+  entity: number;
+  sessionId: string;
+  username: string;
+  tank: TankSnapshot;
+  ammoLoadout: Record<string, number>;
+  ammoCapacity: number;
+}
+
+/**
+ * ProjectileMetadata stores descriptive information about an active projectile that components do
+ * not naturally capture (e.g. ammo name for VFX, shooter identity for scoring, etc.).
+ */
+export interface ProjectileMetadata {
+  entity: number;
+  id: string;
+  ammoName: string;
+  shooterSessionId: string;
+  damage: number;
+  penetration: number;
+  explosion: number;
+}
+
+/**
+ * Utility to deep clone an ammo loadout to avoid mutation leaks across server/client boundaries.
+ */
+export function cloneAmmoLoadout(loadout: AmmoLoadout): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(loadout).map(([key, value]) => [key, Math.max(0, Math.floor(Number(value) || 0))])
+  );
+}

--- a/packages/shared/src/ecs/snapshots.ts
+++ b/packages/shared/src/ecs/snapshots.ts
@@ -1,0 +1,186 @@
+// snapshots.ts
+// Summary: Helper utilities for translating between bitecs component storage and the Colyseus
+//          schema buffers defined in ../schema.ts so both server simulators and client renderers
+//          can share deterministic packing logic.
+// Structure: Provides writer functions that serialise ECS state into schema buffers and reader
+//            functions that hydrate ECS components from schema arrays using caller provided
+//            entity-mapping callbacks.
+// Usage: Server code calls writePlayerRuntimeBuffer before broadcasting; clients call
+//        applyPlayerRuntimeBuffer when patches arrive to update their local worlds.
+// ---------------------------------------------------------------------------
+
+import { addComponent, hasComponent } from 'bitecs';
+import { ArraySchema } from '@colyseus/schema';
+
+import {
+  AmmoStateComponent,
+  CooldownComponent,
+  GameWorld,
+  ProjectileComponent,
+  TransformComponent,
+  VelocityComponent,
+  HealthComponent
+} from './components.js';
+import type { PlayerMetadata, ProjectileMetadata } from './metadata.js';
+import {
+  PlayerRuntimeBufferSchema,
+  ProjectileRuntimeBufferSchema
+} from '../schema.js';
+
+function clearArraySchema<T>(array: ArraySchema<T>): void {
+  array.splice(0, array.length);
+}
+
+/** Serialises all player entities with metadata into the runtime buffer. */
+export function writePlayerRuntimeBuffer(
+  world: GameWorld,
+  metadata: Iterable<PlayerMetadata>,
+  runtime: PlayerRuntimeBufferSchema
+): void {
+  clearArraySchema(runtime.entityId);
+  clearArraySchema(runtime.x);
+  clearArraySchema(runtime.y);
+  clearArraySchema(runtime.z);
+  clearArraySchema(runtime.rot);
+  clearArraySchema(runtime.turret);
+  clearArraySchema(runtime.gun);
+  clearArraySchema(runtime.vx);
+  clearArraySchema(runtime.vy);
+  clearArraySchema(runtime.vz);
+  clearArraySchema(runtime.health);
+  clearArraySchema(runtime.maxHealth);
+  clearArraySchema(runtime.cooldown);
+  clearArraySchema(runtime.ammoRemaining);
+
+  for (const entry of metadata) {
+    const entity = entry.entity;
+    if (!hasComponent(world, TransformComponent, entity)) continue;
+
+    runtime.entityId.push(entity);
+    runtime.x.push(TransformComponent.x[entity] || 0);
+    runtime.y.push(TransformComponent.y[entity] || 0);
+    runtime.z.push(TransformComponent.z[entity] || 0);
+    runtime.rot.push(TransformComponent.rot[entity] || 0);
+    runtime.turret.push(TransformComponent.turret[entity] || 0);
+    runtime.gun.push(TransformComponent.gun[entity] || 0);
+    runtime.vx.push(VelocityComponent.vx[entity] || 0);
+    runtime.vy.push(VelocityComponent.vy[entity] || 0);
+    runtime.vz.push(VelocityComponent.vz[entity] || 0);
+    runtime.health.push(HealthComponent.current[entity] || 0);
+    runtime.maxHealth.push(HealthComponent.max[entity] || 0);
+    runtime.cooldown.push(CooldownComponent.value[entity] || 0);
+    runtime.ammoRemaining.push(AmmoStateComponent.remaining[entity] || 0);
+  }
+}
+
+/** Serialises projectile entities into the projectile runtime buffer. */
+export function writeProjectileRuntimeBuffer(
+  world: GameWorld,
+  projectiles: Iterable<ProjectileMetadata>,
+  buffer: ProjectileRuntimeBufferSchema
+): void {
+  clearArraySchema(buffer.id);
+  clearArraySchema(buffer.entityId);
+  clearArraySchema(buffer.x);
+  clearArraySchema(buffer.y);
+  clearArraySchema(buffer.z);
+  clearArraySchema(buffer.vx);
+  clearArraySchema(buffer.vy);
+  clearArraySchema(buffer.vz);
+  clearArraySchema(buffer.ammo);
+  clearArraySchema(buffer.shooter);
+
+  for (const entry of projectiles) {
+    const entity = entry.entity;
+    if (!hasComponent(world, TransformComponent, entity) || !hasComponent(world, ProjectileComponent, entity)) {
+      continue;
+    }
+    buffer.id.push(entry.id);
+    buffer.entityId.push(entity);
+    buffer.x.push(TransformComponent.x[entity] || 0);
+    buffer.y.push(TransformComponent.y[entity] || 0);
+    buffer.z.push(TransformComponent.z[entity] || 0);
+    buffer.vx.push(ProjectileComponent.vx[entity] || 0);
+    buffer.vy.push(ProjectileComponent.vy[entity] || 0);
+    buffer.vz.push(ProjectileComponent.vz[entity] || 0);
+    buffer.ammo.push(entry.ammoName);
+    buffer.shooter.push(entry.shooterSessionId);
+  }
+}
+
+export type EnsureEntityForId = (serverEntityId: number) => number | null;
+
+/** Hydrates or updates player entities client-side from the runtime buffer. */
+export function applyPlayerRuntimeBuffer(
+  world: GameWorld,
+  runtime: PlayerRuntimeBufferSchema,
+  ensureEntity: EnsureEntityForId
+): Set<number> {
+  const seenEntities = new Set<number>();
+  for (let i = 0; i < runtime.entityId.length; i += 1) {
+    const serverEntity = runtime.entityId[i] ?? 0;
+    const localEntity = ensureEntity(serverEntity);
+    if (localEntity === null) continue;
+
+    if (!hasComponent(world, TransformComponent, localEntity)) {
+      addComponent(world, TransformComponent, localEntity);
+    }
+    if (!hasComponent(world, VelocityComponent, localEntity)) {
+      addComponent(world, VelocityComponent, localEntity);
+    }
+    if (!hasComponent(world, HealthComponent, localEntity)) {
+      addComponent(world, HealthComponent, localEntity);
+    }
+    if (!hasComponent(world, AmmoStateComponent, localEntity)) {
+      addComponent(world, AmmoStateComponent, localEntity);
+    }
+    if (!hasComponent(world, CooldownComponent, localEntity)) {
+      addComponent(world, CooldownComponent, localEntity);
+    }
+
+    TransformComponent.x[localEntity] = runtime.x[i] ?? 0;
+    TransformComponent.y[localEntity] = runtime.y[i] ?? 0;
+    TransformComponent.z[localEntity] = runtime.z[i] ?? 0;
+    TransformComponent.rot[localEntity] = runtime.rot[i] ?? 0;
+    TransformComponent.turret[localEntity] = runtime.turret[i] ?? 0;
+    TransformComponent.gun[localEntity] = runtime.gun[i] ?? 0;
+    VelocityComponent.vx[localEntity] = runtime.vx[i] ?? 0;
+    VelocityComponent.vy[localEntity] = runtime.vy[i] ?? 0;
+    VelocityComponent.vz[localEntity] = runtime.vz[i] ?? 0;
+    HealthComponent.current[localEntity] = runtime.health[i] ?? 0;
+    HealthComponent.max[localEntity] = runtime.maxHealth[i] ?? 0;
+    CooldownComponent.value[localEntity] = runtime.cooldown[i] ?? 0;
+    AmmoStateComponent.remaining[localEntity] = runtime.ammoRemaining[i] ?? 0;
+    seenEntities.add(serverEntity);
+  }
+  return seenEntities;
+}
+
+/** Hydrates projectile ECS entities client-side. */
+export function applyProjectileRuntimeBuffer(
+  world: GameWorld,
+  buffer: ProjectileRuntimeBufferSchema,
+  ensureEntity: EnsureEntityForId
+): Set<number> {
+  const seen = new Set<number>();
+  for (let i = 0; i < buffer.entityId.length; i += 1) {
+    const serverEntity = buffer.entityId[i] ?? 0;
+    const localEntity = ensureEntity(serverEntity);
+    if (localEntity === null) continue;
+    if (!hasComponent(world, TransformComponent, localEntity)) {
+      addComponent(world, TransformComponent, localEntity);
+    }
+    if (!hasComponent(world, ProjectileComponent, localEntity)) {
+      addComponent(world, ProjectileComponent, localEntity);
+    }
+    TransformComponent.x[localEntity] = buffer.x[i] ?? 0;
+    TransformComponent.y[localEntity] = buffer.y[i] ?? 0;
+    TransformComponent.z[localEntity] = buffer.z[i] ?? 0;
+    ProjectileComponent.vx[localEntity] = buffer.vx[i] ?? 0;
+    ProjectileComponent.vy[localEntity] = buffer.vy[i] ?? 0;
+    ProjectileComponent.vz[localEntity] = buffer.vz[i] ?? 0;
+    ProjectileComponent.life[localEntity] = 0;
+    seen.add(serverEntity);
+  }
+  return seen;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,12 +6,37 @@
 
 export { generateGentleHills } from './terrain-noise.js';
 export {
-  PlayerStateSchema,
-  ProjectileStateSchema,
   TanksForNothingState,
+  PlayerMetadataSchema,
+  PlayerRuntimeBufferSchema,
+  ProjectileRuntimeBufferSchema,
   GAME_COMMAND,
   GAME_EVENT,
   type GameCommand,
   type GameEvent,
   type AmmoLoadout
 } from './schema.js';
+export {
+  createGameWorld,
+  createEntity,
+  destroyEntity,
+  TransformComponent,
+  TargetComponent,
+  VelocityComponent,
+  HealthComponent,
+  AmmoStateComponent,
+  CooldownComponent,
+  TankStatsComponent,
+  ProjectileComponent,
+  PlayerTagComponent,
+  type GameWorld
+} from './ecs/components.js';
+export type { PlayerMetadata, ProjectileMetadata, TankSnapshot } from './ecs/metadata.js';
+export {
+  writePlayerRuntimeBuffer,
+  writeProjectileRuntimeBuffer,
+  applyPlayerRuntimeBuffer,
+  applyProjectileRuntimeBuffer,
+  type EnsureEntityForId
+} from './ecs/snapshots.js';
+export { cloneAmmoLoadout } from './ecs/metadata.js';

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -1,18 +1,20 @@
 // schema.ts
-// Summary: Shared Colyseus schema definitions and message identifiers for Tanks for Nothing.
-// Structure: Defines Schema subclasses representing players, projectiles, and top-level game state
-//            alongside string literal message catalogs for client/server communication.
-// Usage: Imported by both the server Colyseus Room and the client networking layer to ensure
-//        synchronized state shapes and consistent message routing without duplicating literals.
+// Summary: Shared Colyseus schema definitions and command/event catalogs, now optimised for ECS
+//          driven replication by packing component data into dense arrays rather than per-player
+//          objects.
+// Structure: Declares metadata maps describing static tank information alongside runtime buffers
+//            for transforms, physics, and projectile state. Also exports command/event literals
+//            consumed by both server and client networking layers.
+// Usage: import { TanksForNothingState, GAME_COMMAND } from '@tanksfornothing/shared';
 // ---------------------------------------------------------------------------
 
-import { Schema, type, MapSchema } from '@colyseus/schema';
+import { Schema, type, MapSchema, ArraySchema } from '@colyseus/schema';
 
 /**
- * PlayerStateSchema captures both static tank configuration and dynamic runtime properties so
- * every client can faithfully reconstruct remote tanks from state patches alone.
+ * PlayerMetadataSchema stores high-level descriptive information keyed by Colyseus sessionId.
  */
-export class PlayerStateSchema extends Schema {
+export class PlayerMetadataSchema extends Schema {
+  @type('number') declare entityId: number;
   @type('string') declare username: string;
   @type('string') declare tankName: string;
   @type('string') declare nation: string;
@@ -41,41 +43,91 @@ export class PlayerStateSchema extends Schema {
   @type('number') declare turretHeight: number;
   @type('number') declare turretXPercent: number;
   @type('number') declare turretYPercent: number;
-  @type('number') declare x: number;
-  @type('number') declare y: number;
-  @type('number') declare z: number;
-  @type('number') declare rot: number;
-  @type('number') declare turret: number;
-  @type('number') declare gun: number;
-  @type('number') declare health: number;
-  @type('number') declare ammoRemaining: number;
+  @type('number') declare ammoCapacity: number;
   @type({ map: 'number' }) declare ammoLoadout: MapSchema<number>;
 }
 
 /**
- * ProjectileStateSchema mirrors the authoritative projectile simulation handled server-side.
+ * PlayerRuntimeBufferSchema represents dense component data mirrored from the authoritative ECS
+ * world. The parallel arrays allow Colyseus patches to send compact diffs even with many players.
  */
-export class ProjectileStateSchema extends Schema {
-  @type('string') declare id: string;
-  @type('number') declare x: number;
-  @type('number') declare y: number;
-  @type('number') declare z: number;
-  @type('number') declare vx: number;
-  @type('number') declare vy: number;
-  @type('number') declare vz: number;
-  @type('string') declare ammo: string;
-  @type('string') declare shooter: string;
+export class PlayerRuntimeBufferSchema extends Schema {
+  @type(['number']) declare entityId: ArraySchema<number>;
+  @type(['number']) declare x: ArraySchema<number>;
+  @type(['number']) declare y: ArraySchema<number>;
+  @type(['number']) declare z: ArraySchema<number>;
+  @type(['number']) declare rot: ArraySchema<number>;
+  @type(['number']) declare turret: ArraySchema<number>;
+  @type(['number']) declare gun: ArraySchema<number>;
+  @type(['number']) declare vx: ArraySchema<number>;
+  @type(['number']) declare vy: ArraySchema<number>;
+  @type(['number']) declare vz: ArraySchema<number>;
+  @type(['number']) declare health: ArraySchema<number>;
+  @type(['number']) declare maxHealth: ArraySchema<number>;
+  @type(['number']) declare cooldown: ArraySchema<number>;
+  @type(['number']) declare ammoRemaining: ArraySchema<number>;
+
+  constructor() {
+    super();
+    this.entityId = new ArraySchema<number>();
+    this.x = new ArraySchema<number>();
+    this.y = new ArraySchema<number>();
+    this.z = new ArraySchema<number>();
+    this.rot = new ArraySchema<number>();
+    this.turret = new ArraySchema<number>();
+    this.gun = new ArraySchema<number>();
+    this.vx = new ArraySchema<number>();
+    this.vy = new ArraySchema<number>();
+    this.vz = new ArraySchema<number>();
+    this.health = new ArraySchema<number>();
+    this.maxHealth = new ArraySchema<number>();
+    this.cooldown = new ArraySchema<number>();
+    this.ammoRemaining = new ArraySchema<number>();
+  }
 }
 
 /**
- * TanksForNothingState is the authoritative root state replicated to every connected client.
+ * ProjectileRuntimeBufferSchema mirrors the projectile ECS archetype for the benefit of clients.
+ */
+export class ProjectileRuntimeBufferSchema extends Schema {
+  @type(['string']) declare id: ArraySchema<string>;
+  @type(['number']) declare entityId: ArraySchema<number>;
+  @type(['number']) declare x: ArraySchema<number>;
+  @type(['number']) declare y: ArraySchema<number>;
+  @type(['number']) declare z: ArraySchema<number>;
+  @type(['number']) declare vx: ArraySchema<number>;
+  @type(['number']) declare vy: ArraySchema<number>;
+  @type(['number']) declare vz: ArraySchema<number>;
+  @type(['string']) declare ammo: ArraySchema<string>;
+  @type(['string']) declare shooter: ArraySchema<string>;
+
+  constructor() {
+    super();
+    this.id = new ArraySchema<string>();
+    this.entityId = new ArraySchema<number>();
+    this.x = new ArraySchema<number>();
+    this.y = new ArraySchema<number>();
+    this.z = new ArraySchema<number>();
+    this.vx = new ArraySchema<number>();
+    this.vy = new ArraySchema<number>();
+    this.vz = new ArraySchema<number>();
+    this.ammo = new ArraySchema<string>();
+    this.shooter = new ArraySchema<string>();
+  }
+}
+
+/**
+ * TanksForNothingState holds authoritative gameplay information replicated to clients.
  */
 export class TanksForNothingState extends Schema {
-  @type({ map: PlayerStateSchema })
-  declare players: MapSchema<PlayerStateSchema>;
+  @type({ map: PlayerMetadataSchema })
+  declare playerMetadata: MapSchema<PlayerMetadataSchema>;
 
-  @type({ map: ProjectileStateSchema })
-  declare projectiles: MapSchema<ProjectileStateSchema>;
+  @type(PlayerRuntimeBufferSchema)
+  declare playerRuntime: PlayerRuntimeBufferSchema;
+
+  @type(ProjectileRuntimeBufferSchema)
+  declare projectileRuntime: ProjectileRuntimeBufferSchema;
 
   @type('string')
   declare terrainName: string;
@@ -83,12 +135,17 @@ export class TanksForNothingState extends Schema {
   @type('number')
   declare terrainRevision: number;
 
+  @type('number')
+  declare tick: number;
+
   constructor() {
     super();
-    this.players = new MapSchema<PlayerStateSchema>();
-    this.projectiles = new MapSchema<ProjectileStateSchema>();
+    this.playerMetadata = new MapSchema<PlayerMetadataSchema>();
+    this.playerRuntime = new PlayerRuntimeBufferSchema();
+    this.projectileRuntime = new ProjectileRuntimeBufferSchema();
     this.terrainName = 'unknown';
     this.terrainRevision = 0;
+    this.tick = 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared bitecs component definitions, schema buffers, and snapshot helpers to back Colyseus replication
- move server gameplay to a ServerWorldController that drives the ECS world and syncs TanksForNothingState
- update the client to consume ECS snapshots via a RemoteWorldRenderer and projectile sync utilities

## Testing
- npm run build:all

------
https://chatgpt.com/codex/tasks/task_e_6900c86073348328a2258d90db7fc805