### PR TITLE
Fix lobby join crash by initialising ammo loadout schema map

### DIFF
--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -45,6 +45,12 @@ export class PlayerMetadataSchema extends Schema {
   @type('number') declare turretYPercent: number;
   @type('number') declare ammoCapacity: number;
   @type({ map: 'number' }) declare ammoLoadout: MapSchema<number>;
+
+  constructor() {
+    super();
+    // Ensure ammoLoadout is always a usable MapSchema so server sync logic can iterate safely
+    this.ammoLoadout = new MapSchema<number>();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- instantiate the player metadata ammoLoadout map so server sync code can safely iterate its keys
- document the intent with inline comments to aid future debugging

## Testing
- npm test *(fails: missing optional dependencies such as bitecs and colyseus in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900f18baf148328a0b8433b93da1466