### PR TITLE
Allow tracking of persisted data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,13 @@ logs/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-data/*.db
-data/*.bak
+
+# Persisted data snapshots
+# Allow committed user/account databases and seed data under data/ by default so
+# they remain version-controlled.
+# Ignore only obvious temporary backups that editors create.
+data/*.tmp
+data/*~
 
 # Environment & OS files
 .env


### PR DESCRIPTION
## Summary
- allow committed data directory assets, including user database files, to be version controlled by default
- limit ignores in the data directory to obvious temporary backup files so seed data remains tracked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901fa99060083289a0121d0b0526dc9