### PR TITLE
Clamp muzzle spawn height to terrain baseline

### DIFF
--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -715,9 +715,12 @@ export class ServerWorldController {
       typeof turretHeightMeta === 'number' && Number.isFinite(turretHeightMeta)
         ? turretHeightMeta
         : TankStatsComponent.turretHeight[entity] || 0;
-    // The gun pivot sits atop the combined hull and turret stack; keep it positive so clamping later remains stable.
-    const pivotHeight = Math.max(0, bodyHeight) + Math.max(0, turretHeight);
-    const pivotY = baselineY + pivotHeight;
+    // The gun pivot sits atop the combined hull and turret stack; start from the centre-based baseline and
+    // add half-height contributions so level shots remain aligned with the previous origin while still
+    // accounting for taller turrets.
+    const halfBodyHeight = Math.max(0, bodyHeight) * 0.5;
+    const halfTurretHeight = Math.max(0, turretHeight) * 0.5;
+    const pivotY = baselineY + halfBodyHeight + halfTurretHeight;
     const muzzleX = TransformComponent.x[entity] + turretYOffset * meta.tank.bodyWidth - sinYaw * cosPitch * barrelLen;
     const unclampedMuzzleY = pivotY + sinPitch * barrelLen;
     // Guard against steep gun depression pushing the muzzle below the terrain baseline, which breaks FX visibility.

--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -697,17 +697,34 @@ export class ServerWorldController {
     const yaw = (TransformComponent.rot[entity] || 0) + (TransformComponent.turret[entity] || 0);
     const pitch = TransformComponent.gun[entity] || 0;
     const cosPitch = Math.cos(pitch);
+    const sinPitch = Math.sin(pitch);
     const sinYaw = Math.sin(yaw);
     const cosYaw = Math.cos(yaw);
     const speed = ammo.speed ?? 200;
     const barrelLen = meta.tank.barrelLength || TankStatsComponent.barrelLength[entity] || 3;
     const turretYOffset = (meta.tank.turretYPercent ?? 50) / 100 - 0.5;
     const turretXOffset = 0.5 - (meta.tank.turretXPercent ?? 50) / 100;
+    const baselineY = TransformComponent.y[entity] || 0;
+    // Use metadata first, but fall back to the authoritative TankStats component when lobby data is missing.
+    const bodyHeight =
+      Number.isFinite(meta.tank.bodyHeight) && typeof meta.tank.bodyHeight === 'number'
+        ? meta.tank.bodyHeight
+        : TankStatsComponent.bodyHeight[entity] || 0;
+    const turretHeightMeta = meta.tank.turretHeight;
+    const turretHeight =
+      typeof turretHeightMeta === 'number' && Number.isFinite(turretHeightMeta)
+        ? turretHeightMeta
+        : TankStatsComponent.turretHeight[entity] || 0;
+    // The gun pivot sits atop the combined hull and turret stack; keep it positive so clamping later remains stable.
+    const pivotHeight = Math.max(0, bodyHeight) + Math.max(0, turretHeight);
+    const pivotY = baselineY + pivotHeight;
     const muzzleX = TransformComponent.x[entity] + turretYOffset * meta.tank.bodyWidth - sinYaw * cosPitch * barrelLen;
-    const muzzleY = TransformComponent.y[entity] + meta.tank.bodyHeight / 2 + Math.sin(pitch) * barrelLen;
+    const unclampedMuzzleY = pivotY + sinPitch * barrelLen;
+    // Guard against steep gun depression pushing the muzzle below the terrain baseline, which breaks FX visibility.
+    const muzzleY = Math.max(baselineY, unclampedMuzzleY);
     const muzzleZ = TransformComponent.z[entity] + turretXOffset * meta.tank.bodyLength - cosYaw * cosPitch * barrelLen;
     const vx = -sinYaw * cosPitch * speed;
-    const vy = Math.sin(pitch) * speed;
+    const vy = sinPitch * speed;
     const vz = -cosYaw * cosPitch * speed;
     return { muzzleX, muzzleY, muzzleZ, vx, vy, vz };
   }

--- a/packages/server/tests/muzzle-clearance.test.ts
+++ b/packages/server/tests/muzzle-clearance.test.ts
@@ -1,0 +1,119 @@
+// muzzle-clearance.test.ts
+// Summary: Ensures depressed cannon shots spawn their muzzle and physics bodies above the ground plane.
+// Structure: Bootstraps a ServerWorldController with a single tank, forces a steep gun depression, fires once,
+//            and checks both ECS and physics spawn heights against the tank's terrain baseline.
+// Usage: Executed via `npm test` which compiles the workspace then runs Node's test runner over dist/tests.
+// ---------------------------------------------------------------------------
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import type { AmmoDefinition, TankDefinition } from '../src/types.js';
+import { TransformComponent } from '@tanksfornothing/shared';
+import { ServerWorldController } from '../src/game/server-world.js';
+
+const ammo: AmmoDefinition = {
+  name: 'UnitTestShell',
+  nation: 'Test',
+  caliber: 75,
+  armorPen: 120,
+  type: 'AP',
+  explosionRadius: 0,
+  pen0: 120,
+  pen100: 100,
+  image: 'unit-test.png',
+  speed: 900,
+  damage: 10,
+  penetration: 120,
+  explosion: 0
+};
+
+const tank: TankDefinition = {
+  name: 'UnitTest Tank',
+  nation: 'Test',
+  br: 1,
+  class: 'Medium Tank',
+  armor: 50,
+  turretArmor: 45,
+  cannonCaliber: 75,
+  ammo: [ammo.name],
+  ammoCapacity: 1,
+  barrelLength: 5,
+  mainCannonFireRate: 10,
+  crew: 4,
+  engineHp: 500,
+  maxSpeed: 40,
+  maxReverseSpeed: 20,
+  incline: 10,
+  bodyRotation: 0,
+  turretRotation: 60,
+  maxTurretIncline: 20,
+  maxTurretDecline: -15,
+  horizontalTraverse: 0,
+  bodyWidth: 3,
+  bodyLength: 6,
+  bodyHeight: 2,
+  turretWidth: 2,
+  turretLength: 3,
+  turretHeight: 1,
+  turretXPercent: 50,
+  turretYPercent: 50
+};
+
+test('muzzle height clamps to terrain during steep depression', () => {
+  const controller = new ServerWorldController({
+    getAmmo: () => [ammo],
+    getTerrain: () => null
+  });
+
+  controller.addPlayer('session', 'Tester', tank, { [ammo.name]: 1 }, 1);
+  const playerMeta = controller.getMetadataForSession('session');
+  assert.ok(playerMeta, 'player metadata should exist after adding a player');
+
+  const entity = playerMeta.entity;
+  TransformComponent.y[entity] = 0;
+  TransformComponent.rot[entity] = 0;
+  TransformComponent.turret[entity] = 0;
+  TransformComponent.gun[entity] = (-60 * Math.PI) / 180;
+
+  // Force metadata turret height to NaN so the compute routine exercises the TankStats fallback path.
+  playerMeta.tank.turretHeight = Number.NaN;
+
+  // Reach into the controller internals to synchronously invoke the fire logic and inspect spawned projectiles.
+  const controllerInternals = controller as unknown as {
+    processFireRequest: (entity: number, request: { ammoName: string }) => boolean;
+    projectileMetadata: Map<string, { entity: number }>;
+    projectileBodies: Map<string, { position: { y: number } }>;
+  };
+
+  const fired = controllerInternals.processFireRequest(entity, { ammoName: ammo.name });
+  assert.ok(fired, 'fire request should succeed with valid ammo');
+
+  const projectiles = [...controllerInternals.projectileMetadata.values()];
+  assert.strictEqual(projectiles.length, 1, 'one projectile should spawn from the shot');
+
+  const projectileEntity = projectiles[0].entity;
+  const muzzleY = TransformComponent.y[projectileEntity];
+  const tankBaseline = TransformComponent.y[entity];
+
+  assert.ok(
+    muzzleY >= tankBaseline,
+    `expected muzzle height ${muzzleY} to stay above terrain baseline ${tankBaseline}`
+  );
+  assert.strictEqual(
+    muzzleY,
+    tankBaseline,
+    'steep depression should clamp muzzle exactly to the baseline when it would otherwise dip underground'
+  );
+
+  const projectileBody = controllerInternals.projectileBodies.values().next().value;
+  assert.ok(projectileBody, 'physics body should be created for the projectile');
+  assert.ok(
+    projectileBody.position.y >= tankBaseline,
+    `expected projectile body spawn height ${projectileBody.position.y} to stay above baseline ${tankBaseline}`
+  );
+  assert.ok(
+    Math.abs(projectileBody.position.y - tankBaseline) < 1e-6,
+    'physics spawn height should mirror the clamped muzzle height'
+  );
+});


### PR DESCRIPTION
## Summary
- include turret height when computing muzzle elevation and clamp the spawn height above the terrain baseline
- ensure projectile bodies inherit the same clamped muzzle origin when firing at steep depression angles
- add a regression test that fires downhill and asserts the muzzle and projectile remain above ground

## Testing
- npm run test --workspace @tanksfornothing/server

------
https://chatgpt.com/codex/tasks/task_e_6903393a1d508328922dcd2cbd69f01f