### PR TITLE
Ensure server gun depression uses negative angles

### DIFF
--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -177,7 +177,13 @@ export class ServerWorldController {
     TankStatsComponent.maxSpeed[entity] = tank.maxSpeed ?? 10;
     TankStatsComponent.maxReverseSpeed[entity] = tank.maxReverseSpeed ?? 5;
     TankStatsComponent.turretRotation[entity] = tank.turretRotation ?? 30;
-    TankStatsComponent.gunDepression[entity] = tank.maxTurretDecline ?? -10;
+    const maxTurretDecline =
+      typeof tank.maxTurretDecline === 'number' && Number.isFinite(tank.maxTurretDecline)
+        ? Math.abs(tank.maxTurretDecline)
+        : 10;
+    // Store depression as a negative angle so downstream radian conversions maintain the
+    // "down is negative" convention enforced by updateTankFromPhysics.
+    TankStatsComponent.gunDepression[entity] = -maxTurretDecline;
     TankStatsComponent.gunElevation[entity] = tank.maxTurretIncline ?? 10;
     TankStatsComponent.barrelLength[entity] = tank.barrelLength ?? 3;
     TankStatsComponent.bodyWidth[entity] = tank.bodyWidth ?? 3;

--- a/packages/server/tests/muzzle-clearance.test.ts
+++ b/packages/server/tests/muzzle-clearance.test.ts
@@ -9,7 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 
 import type { AmmoDefinition, TankDefinition } from '../src/types.js';
-import { TransformComponent, TankStatsComponent } from '@tanksfornothing/shared';
+import { TransformComponent, TankStatsComponent, ProjectileComponent } from '@tanksfornothing/shared';
 import { MUZZLE_TERRAIN_CLEARANCE, ServerWorldController } from '../src/game/server-world.js';
 
 const ammo: AmmoDefinition = {
@@ -116,5 +116,11 @@ test('muzzle height clamps to terrain during steep depression', () => {
   assert.ok(
     Math.abs(projectileBody.position.y - clearanceFloor) < 1e-3,
     'physics spawn height should mirror the clamped muzzle height'
+  );
+
+  const verticalVelocity = ProjectileComponent.vy[projectileEntity];
+  assert.ok(
+    verticalVelocity < 0,
+    `expected depressed shot to start descending, but vy=${verticalVelocity} was not negative`
   );
 });


### PR DESCRIPTION
## Summary
- store tank gun depression limits as negative angles when creating tank stats
- extend the muzzle clearance regression test to confirm depressed shells travel downward

## Testing
- npm run test --workspace @tanksfornothing/server *(fails: TypeScript build cannot locate type definitions for existing dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906265e090c8328b57c32aa1aa65f31