### PR TITLE
Normalize server gun depression handling

### DIFF
--- a/packages/server/src/game/server-world.ts
+++ b/packages/server/src/game/server-world.ts
@@ -177,13 +177,15 @@ export class ServerWorldController {
     TankStatsComponent.maxSpeed[entity] = tank.maxSpeed ?? 10;
     TankStatsComponent.maxReverseSpeed[entity] = tank.maxReverseSpeed ?? 5;
     TankStatsComponent.turretRotation[entity] = tank.turretRotation ?? 30;
-    const maxTurretDecline =
+    const rawTurretDecline =
       typeof tank.maxTurretDecline === 'number' && Number.isFinite(tank.maxTurretDecline)
-        ? Math.abs(tank.maxTurretDecline)
+        ? tank.maxTurretDecline
         : 10;
+    const declineMagnitude = Math.max(0, Math.abs(rawTurretDecline));
+    const signedGunDepression = declineMagnitude === 0 ? 0 : -declineMagnitude;
     // Store depression as a negative angle so downstream radian conversions maintain the
     // "down is negative" convention enforced by updateTankFromPhysics.
-    TankStatsComponent.gunDepression[entity] = -maxTurretDecline;
+    TankStatsComponent.gunDepression[entity] = signedGunDepression;
     TankStatsComponent.gunElevation[entity] = tank.maxTurretIncline ?? 10;
     TankStatsComponent.barrelLength[entity] = tank.barrelLength ?? 3;
     TankStatsComponent.bodyWidth[entity] = tank.bodyWidth ?? 3;

--- a/packages/server/tests/muzzle-clearance.test.ts
+++ b/packages/server/tests/muzzle-clearance.test.ts
@@ -48,7 +48,9 @@ const tank: TankDefinition = {
   bodyRotation: 0,
   turretRotation: 60,
   maxTurretIncline: 20,
-  maxTurretDecline: -15,
+  // The production tank catalogue stores decline as a positive magnitude, so mirror that
+  // convention here to ensure the server normalises it into a negative clamp value.
+  maxTurretDecline: 15,
   horizontalTraverse: 0,
   bodyWidth: 3,
   bodyLength: 6,
@@ -71,6 +73,11 @@ test('muzzle height clamps to terrain during steep depression', () => {
   assert.ok(playerMeta, 'player metadata should exist after adding a player');
 
   const entity = playerMeta.entity;
+  assert.strictEqual(
+    TankStatsComponent.gunDepression[entity],
+    -tank.maxTurretDecline,
+    'gun depression should be stored as a negative degree magnitude'
+  );
   TransformComponent.y[entity] = 0;
   TransformComponent.rot[entity] = 0;
   TransformComponent.turret[entity] = 0;


### PR DESCRIPTION
## Summary
- normalise turret decline values when initialising TankStats so depressed shots clamp below the horizon
- update the muzzle-clearance regression to cover positive decline data and assert the stored ECS value

## Testing
- npm test *(fails: TypeScript build missing external dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_69061f18925c8328816a39ed5dd93510